### PR TITLE
Fix lint error in main Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
           path: builds
   releaseToStore:
     name: Release to Google Play and the App Store
-    runs-on: macOS-latest
+    runs-on: macos-latest
     needs: buildForAllPlatforms
     if: github.event.action == 'published'
     env:


### PR DESCRIPTION
Negligible issue, but in case you ever try to lint you GitHub Action, the casing of "macOS" (should be lowercase) might fail it.

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/4010305/88472178-c5cb1c80-ced5-11ea-87e5-15adcae7729f.png">
