### PR TITLE
Allow tap in gamePlayZones and use gameDefaultCardAction instead of flip

### DIFF
--- a/Assets/Scripts/Cgs/Play/PlayController.cs
+++ b/Assets/Scripts/Cgs/Play/PlayController.cs
@@ -509,7 +509,7 @@ namespace Cgs.Play
 
             cardZone.type = CardZoneType.Horizontal;
             cardZone.allowsFlip = true;
-            cardZone.allowsRotation = false;
+            cardZone.allowsRotation = true;
             cardZone.scrollRectContainer = playArea;
             cardZone.DoesImmediatelyRelease = true;
 
@@ -551,7 +551,7 @@ namespace Cgs.Play
 
             cardZone.type = CardZoneType.Vertical;
             cardZone.allowsFlip = true;
-            cardZone.allowsRotation = false;
+            cardZone.allowsRotation = true;
             cardZone.scrollRectContainer = playArea;
             cardZone.DoesImmediatelyRelease = true;
 
@@ -587,7 +587,7 @@ namespace Cgs.Play
                 return;
 
             cardModel.SecondaryDragAction = cardModel.UpdateParentCardZoneScrollRect;
-            cardModel.DefaultAction = CardActions.Flip;
+            cardModel.DefaultAction = CardActions.ActionsDictionary[CardGameManager.Current.GameDefaultCardAction];
         }
 
         private static void OnAddCardModelFaceDown(CardZone cardZone, CardModel cardModel)
@@ -596,7 +596,7 @@ namespace Cgs.Play
                 return;
 
             cardModel.SecondaryDragAction = cardModel.UpdateParentCardZoneScrollRect;
-            cardModel.DefaultAction = CardActions.Flip;
+            cardModel.DefaultAction = CardActions.ActionsDictionary[CardGameManager.Current.GameDefaultCardAction];
             cardModel.IsFacedown = true;
         }
 
@@ -606,7 +606,7 @@ namespace Cgs.Play
                 return;
 
             cardModel.SecondaryDragAction = cardModel.UpdateParentCardZoneScrollRect;
-            cardModel.DefaultAction = CardActions.Flip;
+            cardModel.DefaultAction = CardActions.ActionsDictionary[CardGameManager.Current.GameDefaultCardAction];
             cardModel.IsFacedown = false;
         }
 

--- a/Assets/StreamingAssets/google-services-desktop.json.meta
+++ b/Assets/StreamingAssets/google-services-desktop.json.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ef862750af0ccf94e9841129e921b85e
+guid: 6cf6d71983fb6a644b3daa1e60a16064
 TextScriptImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
I have been playing around with Unity for a little while and wanted to try my hand at updating a game I actually use! This PR is making the changes I suggested in the Discord. I'm not quite sure why the google-services-desktop.json.meta has changes, but was hoping you might know.

I appreciate any feedback!