### PR TITLE
Fix card backs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,7 +150,7 @@ jobs:
           sed -i 's/\([A-Za-z0-9.-]\+csproj\)/Card-Game-Simulator\/&/g' Card-Game-Simulator.sln
           mv Card-Game-Simulator.sln ..
           cd ..
-          wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
+          curl --proto "=https" -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
           chmod +x ./dotnet-install.sh
           ./dotnet-install.sh --version latest
           apt-get update

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,7 +150,7 @@ jobs:
           sed -i 's/\([A-Za-z0-9.-]\+csproj\)/Card-Game-Simulator\/&/g' Card-Game-Simulator.sln
           mv Card-Game-Simulator.sln ..
           cd ..
-          curl --proto "=https" -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+          curl --proto "=https" -fsSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
           chmod +x ./dotnet-install.sh
           ./dotnet-install.sh --version latest
           apt-get update

--- a/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
+++ b/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
@@ -827,10 +827,6 @@ namespace FinolDigital.Cgs.Json.Unity
             if (cardJToken["backs"] is JArray jArray)
                 backs = jArray.Select(token => token?.Type == JTokenType.String ? token.Value<string>() : null).ToList();
 
-            var effectiveBackFaceId = backs.Count > 0 ? backs[0] : string.Empty;
-            if (string.IsNullOrEmpty(effectiveBackFaceId) && cardJToken["backFaceId"] != null)
-                effectiveBackFaceId = cardJToken.Value<string>("backFaceId") ?? string.Empty;
-
             var cardImageWebUrl = string.Empty;
             var backCardImageWebUrl = string.Empty;
             if (!string.IsNullOrEmpty(CardImageProperty))
@@ -915,7 +911,7 @@ namespace FinolDigital.Cgs.Json.Unity
                         ? cardId + PropertyDef.ObjectDelimiter + set.Key
                         : cardId;
                     var unityCard = new UnityCard(this, cardDuplicateId, cardName, set.Key, cardProperties,
-                            isReprint, false, effectiveBackFaceId)
+                            isReprint)
                         {
                             ImageFileType = cardImageFileType,
                             ImageWebUrl = cardImageWebUrl

--- a/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
+++ b/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
@@ -824,8 +824,16 @@ namespace FinolDigital.Cgs.Json.Unity
             PopulateCardSets(cardSets, cardJToken, defaultSetCode);
 
             var backs = new List<string>();
+            var hasBacksDefinition = cardJToken["backs"] != null;
             if (cardJToken["backs"] is JArray jArray)
                 backs = jArray.Select(token => token?.Type == JTokenType.String ? token.Value<string>() : null).ToList();
+            else
+            {
+                // Legacy field fallback: only use backFaceId when there is no 'backs' array defined
+                var backFaceId = cardJToken.Value<string>("backFaceId");
+                if (!string.IsNullOrEmpty(backFaceId))
+                    backs.Add(backFaceId);
+            }
 
             var cardImageWebUrl = string.Empty;
             var backCardImageWebUrl = string.Empty;
@@ -910,12 +918,54 @@ namespace FinolDigital.Cgs.Json.Unity
                     var cardDuplicateId = cardSets.Count > 1 && isReprint
                         ? cardId + PropertyDef.ObjectDelimiter + set.Key
                         : cardId;
-                    var unityCard = new UnityCard(this, cardDuplicateId, cardName, set.Key, cardProperties,
-                            isReprint)
+                    // Determine primary/back cards behavior:
+                    // - If 'backs' was present in the source JSON, the primary card's BackFaceId should be the
+                    //   first element (empty/null -> empty string). Any subsequent non-empty backs become separate
+                    //   back-face cards with id "<cardId>.<backId>".
+                    // - If 'backs' was not present but a legacy 'backFaceId' exists, treat that as the primary card's
+                    //   BackFaceId (do not create a separate back card).
+                    UnityCard unityCard;
+                    if (hasBacksDefinition)
+                    {
+                        var primaryBack = backs.Count > 0 ? (backs[0] ?? string.Empty) : string.Empty;
+                        unityCard = new UnityCard(this, cardDuplicateId, cardName, set.Key, cardProperties, isReprint,
+                            false, primaryBack)
                         {
                             ImageFileType = cardImageFileType,
                             ImageWebUrl = cardImageWebUrl
                         };
+                        // Always add the primary/front card when 'backs' defined
+                        LoadedCards[unityCard.Id] = unityCard;
+                        isReprint = true; // subsequent back cards are considered reprints
+
+                        // Create separate back cards for subsequent usable backs
+                        for (var bi = 1; bi < backs.Count; bi++)
+                        {
+                            var backId = backs[bi];
+                            if (string.IsNullOrEmpty(backId))
+                                continue;
+                            var backCardId = cardDuplicateId + PropertyDef.ObjectDelimiter + backId;
+                            var backUnityCard = new UnityCard(this, backCardId, cardName, set.Key, cardProperties,
+                                isReprint, false, backId)
+                            {
+                                ImageFileType = cardImageFileType,
+                                ImageWebUrl = cardImageWebUrl
+                            };
+                            LoadedCards[backUnityCard.Id] = backUnityCard;
+                        }
+                    }
+                    else
+                    {
+                        var primaryBack = backs.Count > 0 ? backs[0] ?? string.Empty : string.Empty;
+                        unityCard = new UnityCard(this, cardDuplicateId, cardName, set.Key, cardProperties, isReprint,
+                            false, primaryBack)
+                        {
+                            ImageFileType = cardImageFileType,
+                            ImageWebUrl = cardImageWebUrl
+                        };
+                        LoadedCards[unityCard.Id] = unityCard;
+                        isReprint = true;
+                    }
                     if (!string.IsNullOrEmpty(cardBackName))
                     {
                         var backCardId = cardDuplicateId + "_b";
@@ -934,27 +984,10 @@ namespace FinolDigital.Cgs.Json.Unity
                                 ImageWebUrl = backCardImageWebUrl
                             };
                         LoadedCards[backUnityCard.Id] = backUnityCard;
-                    }
-
-                    if (backs.Contains(null) || backs.Contains(string.Empty) || backs.Count < 1)
-                    {
+                        // Ensure the front/main card mapping is updated to the back-face pair
                         LoadedCards[unityCard.Id] = unityCard;
-                        isReprint = true;
                     }
-
-                    foreach (var backId in backs)
-                    {
-                        if (string.IsNullOrEmpty(backId))
-                            continue;
-                        var backCardId = cardDuplicateId + PropertyDef.ObjectDelimiter + backId;
-                        var backUnityCard =
-                            new UnityCard(this, backCardId, cardName, set.Key, cardProperties, isReprint, false, backId)
-                            {
-                                ImageFileType = cardImageFileType,
-                                ImageWebUrl = cardImageWebUrl
-                            };
-                        LoadedCards[backUnityCard.Id] = backUnityCard;
-                    }
+                    // Note: back cards from 'backs' have already been added when appropriate
                 }
             }
             else

--- a/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
+++ b/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
@@ -824,13 +824,14 @@ namespace FinolDigital.Cgs.Json.Unity
             PopulateCardSets(cardSets, cardJToken, defaultSetCode);
 
             var backs = new List<string>();
+            var hasBacksDefinition = cardJToken["backs"] != null;
             if (cardJToken["backs"] is JArray jArray)
                 backs = jArray.ToObject<List<string>>();
 
             var hasUsableBacks = backs.Any(backId => !string.IsNullOrEmpty(backId));
             var hasSingleNonEmptyBack = backs.Count == 1 && !string.IsNullOrEmpty(backs[0]);
             var effectiveBackFaceId = hasSingleNonEmptyBack ? backs[0] : string.Empty;
-            if (string.IsNullOrEmpty(effectiveBackFaceId) && !hasUsableBacks)
+            if (string.IsNullOrEmpty(effectiveBackFaceId) && !hasBacksDefinition)
                 effectiveBackFaceId = cardJToken.Value<string>("backFaceId") ?? string.Empty;
 
             var cardImageWebUrl = string.Empty;
@@ -942,13 +943,7 @@ namespace FinolDigital.Cgs.Json.Unity
                         LoadedCards[backUnityCard.Id] = backUnityCard;
                     }
 
-                    if (!hasUsableBacks)
-                    {
-                        LoadedCards[unityCard.Id] = unityCard;
-                        isReprint = true;
-                    }
-
-                    if (hasSingleNonEmptyBack)
+                    if (!hasUsableBacks || hasSingleNonEmptyBack)
                     {
                         LoadedCards[unityCard.Id] = unityCard;
                         isReprint = true;
@@ -1335,13 +1330,14 @@ namespace FinolDigital.Cgs.Json.Unity
                 if (cardToken.Value<bool?>("isBackFaceCard") ?? false)
                     continue;
 
+                var hasBacksDefinition = cardToken["backs"] != null;
                 var backs = cardToken["backs"] as JArray;
                 var hasUsableBacks = backs?.Any(token => !string.IsNullOrEmpty(token.Value<string>())) ?? false;
                 var backFaceId = cardToken.Value<string>("backFaceId") ?? string.Empty;
 
-                if (!hasUsableBacks && !string.IsNullOrEmpty(backFaceId))
+                if (!hasUsableBacks && !string.IsNullOrEmpty(backFaceId) && !hasBacksDefinition)
                     cardToken["backs"] = new JArray(backFaceId);
-                else if (string.IsNullOrEmpty(backFaceId) && !hasUsableBacks)
+                else if (!hasUsableBacks)
                     cardToken.Remove("backs");
 
                 cardToken.Remove("backFaceId");

--- a/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
+++ b/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
@@ -964,7 +964,6 @@ namespace FinolDigital.Cgs.Json.Unity
                             ImageWebUrl = cardImageWebUrl
                         };
                         LoadedCards[unityCard.Id] = unityCard;
-                        isReprint = true;
                     }
                     if (!string.IsNullOrEmpty(cardBackName))
                     {

--- a/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
+++ b/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
@@ -824,17 +824,11 @@ namespace FinolDigital.Cgs.Json.Unity
             PopulateCardSets(cardSets, cardJToken, defaultSetCode);
 
             var backs = new List<string>();
-            var hasBacksDefinition = cardJToken["backs"] != null;
             if (cardJToken["backs"] is JArray jArray)
                 backs = jArray.Select(token => token?.Type == JTokenType.String ? token.Value<string>() : null).ToList();
 
-            var usableBacks = backs.Where(backId => !string.IsNullOrWhiteSpace(backId))
-                .Select(backId => backId.Trim())
-                .ToList();
-            var hasUsableBacks = usableBacks.Count > 0;
-            var hasSingleNonEmptyBack = usableBacks.Count == 1 && backs.Count == 1;
-            var effectiveBackFaceId = hasSingleNonEmptyBack ? usableBacks[0] : string.Empty;
-            if (string.IsNullOrEmpty(effectiveBackFaceId) && !hasBacksDefinition)
+            var effectiveBackFaceId = backs.Count > 0 ? backs[0] : string.Empty;
+            if (string.IsNullOrEmpty(effectiveBackFaceId) && cardJToken["backFaceId"] != null)
                 effectiveBackFaceId = cardJToken.Value<string>("backFaceId") ?? string.Empty;
 
             var cardImageWebUrl = string.Empty;
@@ -946,7 +940,7 @@ namespace FinolDigital.Cgs.Json.Unity
                         LoadedCards[backUnityCard.Id] = backUnityCard;
                     }
 
-                    if (!hasUsableBacks || hasSingleNonEmptyBack)
+                    if (backs.Contains(null) || backs.Contains(string.Empty) || backs.Count < 1)
                     {
                         LoadedCards[unityCard.Id] = unityCard;
                         isReprint = true;
@@ -954,8 +948,6 @@ namespace FinolDigital.Cgs.Json.Unity
 
                     foreach (var backId in backs)
                     {
-                        if (hasSingleNonEmptyBack)
-                            break;
                         if (string.IsNullOrEmpty(backId))
                             continue;
                         var backCardId = cardDuplicateId + PropertyDef.ObjectDelimiter + backId;

--- a/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
+++ b/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
@@ -827,7 +827,7 @@ namespace FinolDigital.Cgs.Json.Unity
             var hasBacksDefinition = cardJToken["backs"] != null;
             if (cardJToken["backs"] is JArray jArray)
                 backs = jArray.Select(token => token?.Type == JTokenType.String ? token.Value<string>() : null).ToList();
-            else
+            else if (!hasBacksDefinition)
             {
                 // Legacy field fallback: only use backFaceId when there is no 'backs' array defined
                 var backFaceId = cardJToken.Value<string>("backFaceId");

--- a/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
+++ b/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
@@ -936,9 +936,9 @@ namespace FinolDigital.Cgs.Json.Unity
                         };
                         // Always add the primary/front card when 'backs' defined
                         LoadedCards[unityCard.Id] = unityCard;
-                        isReprint = true; // subsequent back cards are considered reprints
 
                         // Create separate back cards for subsequent usable backs
+                        const bool variantIsReprint = true;
                         for (var bi = 1; bi < backs.Count; bi++)
                         {
                             var backId = backs[bi];
@@ -946,7 +946,7 @@ namespace FinolDigital.Cgs.Json.Unity
                                 continue;
                             var backCardId = cardDuplicateId + PropertyDef.ObjectDelimiter + backId;
                             var backUnityCard = new UnityCard(this, backCardId, cardName, set.Key, cardProperties,
-                                isReprint, false, backId)
+                                variantIsReprint, false, backId)
                             {
                                 ImageFileType = cardImageFileType,
                                 ImageWebUrl = cardImageWebUrl

--- a/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
+++ b/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
@@ -826,11 +826,14 @@ namespace FinolDigital.Cgs.Json.Unity
             var backs = new List<string>();
             var hasBacksDefinition = cardJToken["backs"] != null;
             if (cardJToken["backs"] is JArray jArray)
-                backs = jArray.ToObject<List<string>>();
+                backs = jArray.Select(token => token?.Type == JTokenType.String ? token.Value<string>() : null).ToList();
 
-            var hasUsableBacks = backs.Any(backId => !string.IsNullOrEmpty(backId));
-            var hasSingleNonEmptyBack = backs.Count == 1 && !string.IsNullOrEmpty(backs[0]);
-            var effectiveBackFaceId = hasSingleNonEmptyBack ? backs[0] : string.Empty;
+            var usableBacks = backs.Where(backId => !string.IsNullOrWhiteSpace(backId))
+                .Select(backId => backId.Trim())
+                .ToList();
+            var hasUsableBacks = usableBacks.Count > 0;
+            var hasSingleNonEmptyBack = usableBacks.Count == 1 && backs.Count == 1;
+            var effectiveBackFaceId = hasSingleNonEmptyBack ? usableBacks[0] : string.Empty;
             if (string.IsNullOrEmpty(effectiveBackFaceId) && !hasBacksDefinition)
                 effectiveBackFaceId = cardJToken.Value<string>("backFaceId") ?? string.Empty;
 

--- a/Assets/Tests/PlayMode/CardBacksTests.cs
+++ b/Assets/Tests/PlayMode/CardBacksTests.cs
@@ -142,6 +142,13 @@ namespace Tests.PlayMode
                     ["set"] = Set.DefaultCode,
                     ["backs"] = new JArray(string.Empty, JValue.CreateNull()),
                     ["backFaceId"] = "LEGACY_MIXED_BACK"
+                },
+                new JObject
+                {
+                    ["id"] = "half_empty_back",
+                    ["name"] = "Half Empty",
+                    ["set"] = Set.DefaultCode,
+                    ["backs"] = new JArray(string.Empty, "BACK_2")
                 }
             };
 
@@ -153,6 +160,9 @@ namespace Tests.PlayMode
 
             Assert.IsTrue(game.Cards.TryGetValue("mixed_empty_back", out var mixedEmptyCard));
             Assert.IsTrue(string.IsNullOrEmpty(mixedEmptyCard.BackFaceId));
+
+            Assert.IsTrue(game.Cards.TryGetValue("half_empty_back", out var halfEmptyCard));
+            Assert.IsTrue(string.IsNullOrEmpty(halfEmptyCard.BackFaceId));
 
             Directory.Delete(game.GameDirectoryPath, true);
         }

--- a/Assets/Tests/PlayMode/CardBacksTests.cs
+++ b/Assets/Tests/PlayMode/CardBacksTests.cs
@@ -52,7 +52,7 @@ namespace Tests.PlayMode
         }
 
         [Test]
-        public void LoadCards_UsesBacks()
+        public void LoadCards_UsesBacksAndFallbacksToBackFaceId()
         {
             var game = new UnityCardGame(null, "load_backs_test_" + Guid.NewGuid())
             {
@@ -77,14 +77,15 @@ namespace Tests.PlayMode
                     ["id"] = "both_back",
                     ["name"] = "Both",
                     ["set"] = Set.DefaultCode,
-                    ["backs"] = new JArray("PREFERRED_BACK"),
+                    ["backs"] = new JArray("BACK_1", "BACK_2"),
                     ["backFaceId"] = "LEGACY_SHOULD_NOT_WIN"
                 },
                 new JObject
                 {
-                    ["id"] = "default_back",
-                    ["name"] = "Default",
-                    ["set"] = Set.DefaultCode
+                    ["id"] = "legacy_back",
+                    ["name"] = "Legacy",
+                    ["set"] = Set.DefaultCode,
+                    ["backFaceId"] = "LEGACY_BACK"
                 }
             };
 
@@ -95,10 +96,13 @@ namespace Tests.PlayMode
             Assert.AreEqual("CANON_BACK", canonicalCard.BackFaceId);
 
             Assert.IsTrue(game.Cards.TryGetValue("both_back", out var bothCard));
-            Assert.AreEqual("PREFERRED_BACK", bothCard.BackFaceId);
+            Assert.AreEqual("BACK_1", bothCard.BackFaceId);
 
-            Assert.IsTrue(game.Cards.TryGetValue("default_back", out var defaultCard));
-            Assert.IsTrue(string.IsNullOrEmpty(defaultCard.BackFaceId));
+            Assert.IsTrue(game.Cards.TryGetValue("both_back.BACK_2", out var bothCard2));
+            Assert.AreEqual("BACK_2", bothCard2.BackFaceId);
+
+            Assert.IsTrue(game.Cards.TryGetValue("legacy_back", out var legacyBack));
+            Assert.AreEqual("LEGACY_BACK", legacyBack.BackFaceId);
 
             Directory.Delete(game.GameDirectoryPath, true);
         }
@@ -119,6 +123,12 @@ namespace Tests.PlayMode
             {
                 new JObject
                 {
+                    ["id"] = "default_back",
+                    ["name"] = "Default",
+                    ["set"] = Set.DefaultCode
+                },
+                new JObject
+                {
                     ["id"] = "null_only_back",
                     ["name"] = "Null Only",
                     ["set"] = Set.DefaultCode,
@@ -127,32 +137,39 @@ namespace Tests.PlayMode
                 },
                 new JObject
                 {
-                    ["id"] = "mixed_empty_back",
-                    ["name"] = "Mixed Empty",
+                    ["id"] = "string_empty_back",
+                    ["name"] = "String Empty",
                     ["set"] = Set.DefaultCode,
-                    ["backs"] = new JArray(string.Empty, JValue.CreateNull()),
-                    ["backFaceId"] = "LEGACY_MIXED_BACK"
+                    ["backs"] = new JArray(string.Empty),
+                    ["backFaceId"] = "LEGACY_STRING_EMPTY_BACK"
                 },
                 new JObject
                 {
-                    ["id"] = "half_empty_back",
-                    ["name"] = "Half Empty",
+                    ["id"] = "double_back",
+                    ["name"] = "Double Empty",
                     ["set"] = Set.DefaultCode,
-                    ["backs"] = new JArray(string.Empty, "BACK_2")
+                    ["backs"] = new JArray(string.Empty, "BACK_2"),
+                    ["backFaceId"] = "LEGACY_DOUBLE_BACK"
                 }
             };
 
             File.WriteAllText(game.CardsFilePath, allCards.ToString(Formatting.None));
             game.LoadCards(game.CardsFilePath, Set.DefaultCode);
 
+            Assert.IsTrue(game.Cards.TryGetValue("default_back", out var defaultCard));
+            Assert.AreEqual("", defaultCard.BackFaceId);
+
             Assert.IsTrue(game.Cards.TryGetValue("null_only_back", out var nullOnlyCard));
-            Assert.IsTrue(string.IsNullOrEmpty(nullOnlyCard.BackFaceId));
+            Assert.AreEqual("", nullOnlyCard.BackFaceId);
 
-            Assert.IsTrue(game.Cards.TryGetValue("mixed_empty_back", out var mixedEmptyCard));
-            Assert.IsTrue(string.IsNullOrEmpty(mixedEmptyCard.BackFaceId));
+            Assert.IsTrue(game.Cards.TryGetValue("string_empty_back", out var stringEmptyCard));
+            Assert.AreEqual("", stringEmptyCard.BackFaceId);
 
-            Assert.IsTrue(game.Cards.TryGetValue("half_empty_back", out var halfEmptyCard));
-            Assert.IsTrue(string.IsNullOrEmpty(halfEmptyCard.BackFaceId));
+            Assert.IsTrue(game.Cards.TryGetValue("double_back", out var doubleBackCard));
+            Assert.AreEqual("", doubleBackCard.BackFaceId);
+
+            Assert.IsTrue(game.Cards.TryGetValue("double_back.BACK_2", out var doubleBackCard2));
+            Assert.AreEqual("BACK_2", doubleBackCard2.BackFaceId);
 
             Directory.Delete(game.GameDirectoryPath, true);
         }

--- a/Assets/Tests/PlayMode/CardBacksTests.cs
+++ b/Assets/Tests/PlayMode/CardBacksTests.cs
@@ -52,7 +52,7 @@ namespace Tests.PlayMode
         }
 
         [Test]
-        public void LoadCards_UsesBacksThenBackFaceIdFallback()
+        public void LoadCards_UsesBacks()
         {
             var game = new UnityCardGame(null, "load_backs_test_" + Guid.NewGuid())
             {
@@ -65,13 +65,6 @@ namespace Tests.PlayMode
 
             var allCards = new JArray
             {
-                new JObject
-                {
-                    ["id"] = "legacy_back",
-                    ["name"] = "Legacy",
-                    ["set"] = Set.DefaultCode,
-                    ["backFaceId"] = "LEGACY_BACK"
-                },
                 new JObject
                 {
                     ["id"] = "canonical_back",
@@ -97,9 +90,6 @@ namespace Tests.PlayMode
 
             File.WriteAllText(game.CardsFilePath, allCards.ToString(Formatting.None));
             game.LoadCards(game.CardsFilePath, Set.DefaultCode);
-
-            Assert.IsTrue(game.Cards.TryGetValue("legacy_back", out var legacyCard));
-            Assert.AreEqual("LEGACY_BACK", legacyCard.BackFaceId);
 
             Assert.IsTrue(game.Cards.TryGetValue("canonical_back", out var canonicalCard));
             Assert.AreEqual("CANON_BACK", canonicalCard.BackFaceId);

--- a/Assets/Tests/PlayMode/CardBacksTests.cs
+++ b/Assets/Tests/PlayMode/CardBacksTests.cs
@@ -52,7 +52,7 @@ namespace Tests.PlayMode
         }
 
         [Test]
-        public void LoadCards_UsesBacksAndFallbacksToBackFaceId()
+        public void LoadCards_UsesBacksAndFallsBackToBackFaceId()
         {
             var game = new UnityCardGame(null, "load_backs_test_" + Guid.NewGuid())
             {

--- a/Assets/Tests/PlayMode/CardBacksTests.cs
+++ b/Assets/Tests/PlayMode/CardBacksTests.cs
@@ -114,7 +114,7 @@ namespace Tests.PlayMode
         }
 
         [Test]
-        public void LoadCards_UsesLegacyBackFaceIdWhenBacksAreUnusable()
+        public void LoadCards_UsesDefaultBackWhenBacksAreUnusable()
         {
             var game = new UnityCardGame(null, "load_unusable_backs_test_" + Guid.NewGuid())
             {
@@ -149,10 +149,10 @@ namespace Tests.PlayMode
             game.LoadCards(game.CardsFilePath, Set.DefaultCode);
 
             Assert.IsTrue(game.Cards.TryGetValue("null_only_back", out var nullOnlyCard));
-            Assert.AreEqual("LEGACY_NULL_BACK", nullOnlyCard.BackFaceId);
+            Assert.IsTrue(string.IsNullOrEmpty(nullOnlyCard.BackFaceId));
 
             Assert.IsTrue(game.Cards.TryGetValue("mixed_empty_back", out var mixedEmptyCard));
-            Assert.AreEqual("LEGACY_MIXED_BACK", mixedEmptyCard.BackFaceId);
+            Assert.IsTrue(string.IsNullOrEmpty(mixedEmptyCard.BackFaceId));
 
             Directory.Delete(game.GameDirectoryPath, true);
         }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -1022,6 +1022,7 @@ PlayerSettings:
   syncCapabilities: 0
   platformCapabilities:
     WindowsStoreApps:
+      CodeGeneration: False
       OfflineMapsManagement: False
       HumanInterfaceDevice: False
       Location: False
@@ -1034,7 +1035,6 @@ PlayerSettings:
       InternetClientServer: True
       VideosLibrary: False
       Objects3D: False
-      InternetClient: True
       RemoteSystem: False
       BlockedChatMessages: False
       PhoneCall: False
@@ -1057,7 +1057,7 @@ PlayerSettings:
       RecordedCallsFolder: False
       Contacts: False
       Proximity: False
-      CodeGeneration: False
+      InternetClient: True
       BackgroundMediaPlayback: False
       EnterpriseAuthentication: False
   metroTargetDeviceFamilies:


### PR DESCRIPTION
This pull request updates the logic for handling card back definitions in the card loading and serialization process, clarifying the fallback behavior and improving consistency. The changes also update related tests to reflect the new expected outcomes.

**Card Back Handling Logic Improvements:**

* Updated the logic in `LoadCardFromJToken` to only fall back to `backFaceId` if the `backs` property is not defined, instead of if it is empty or unusable. This clarifies the precedence and avoids using legacy values when `backs` is present but empty.
* Adjusted the logic for adding cards to `LoadedCards` to handle cases where `backs` is either unusable or contains a single valid entry, ensuring more accurate card loading and reprint detection.
* In `WriteAllCardsJson`, changed the serialization logic to only generate a `backs` array from `backFaceId` if `backs` is not defined, and to remove `backs` if it is empty or unusable, ensuring serialized output matches the new logic.

**Test Updates:**

* Renamed the test `LoadCards_UsesLegacyBackFaceIdWhenBacksAreUnusable` to `LoadCards_UsesDefaultBackWhenBacksAreUnusable` to better reflect the new logic and expectations.
* Updated test assertions to expect an empty `BackFaceId` when `backs` is unusable, matching the revised fallback behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified card-back handling: explicit backs are honored (primary uses first entry; additional backs created only for subsequent usable entries), empty/null entries are skipped, and legacy backFaceId is used only when backs is absent; normalized exports synthesize/remove backs as needed and always drop backFaceId.

* **Tests**
  * Renamed and updated tests to cover usable, mixed, and unusable backs and verify back-face resolution.

* **Chores**
  * CI workflow: switch to using curl to fetch the .NET installer script.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/finol-digital/Card-Game-Simulator/pull/444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->