### PR TITLE
Show card stack owner name in move menu for multiplayer

### DIFF
--- a/Assets/Scripts/Cgs/Play/MoveMenu.cs
+++ b/Assets/Scripts/Cgs/Play/MoveMenu.cs
@@ -3,9 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 using System.Collections.Generic;
+using System.Linq;
 using Cgs.CardGameView;
 using Cgs.CardGameView.Multiplayer;
 using Cgs.Menu;
+using Cgs.Play.Multiplayer;
 using Cgs.UI;
 using JetBrains.Annotations;
 using UnityEngine;
@@ -99,10 +101,27 @@ namespace Cgs.Play
                         string.IsNullOrEmpty(cardZone.Name) ? DefaultZoneName : cardZone.Name);
 
             foreach (var cardStack in PlayController.Instance.AllCardStacks)
+            {
+                var stackName = string.IsNullOrEmpty(cardStack.Name)
+                    ? PlayController.DefaultStackName
+                    : cardStack.Name;
+                var ownerName = GetOwnerName(cardStack);
                 cardContainerOptions.Add(cardStack,
-                    string.IsNullOrEmpty(cardStack.Name) ? PlayController.DefaultStackName : cardStack.Name);
+                    string.IsNullOrEmpty(ownerName) ? stackName : $"{stackName} ({ownerName})");
+            }
 
             Rebuild(cardContainerOptions, SelectCardContainer, _selectedCardContainer);
+        }
+
+        private static string GetOwnerName(CardStack cardStack)
+        {
+            if (CgsNetManager.Instance == null || !CgsNetManager.Instance.IsOnline || !cardStack.IsSpawned)
+                return string.Empty;
+
+            var owner = GameObject.FindGameObjectsWithTag("Player")
+                .Select(player => player.GetComponent<CgsNetPlayer>())
+                .FirstOrDefault(player => player != null && player.OwnerClientId == cardStack.OwnerClientId);
+            return owner == null ? string.Empty : owner.Name;
         }
 
         [UsedImplicitly]


### PR DESCRIPTION
## Summary
- In multiplayer games, the move menu now shows each card stack's owner in parentheses after the stack name, e.g. a stack named "Deck" owned by "davidmfinol" displays as "Deck (davidmfinol)".
- The owner name is resolved by matching the stack's `OwnerClientId` against the `CgsNetPlayer` objects in the scene (same lookup approach as the Scoreboard).
- Single-player/offline games are unchanged: the owner suffix is only added when the stack is network-spawned and the game is online.

## Test plan
- [x] Solution builds with 0 errors (`dotnet build`)
- [x] Single-player: move menu shows stack names without any suffix
- [x] Multiplayer: each card stack shows "Name (owner)" in the move menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Card stack selection options now show the owning player’s name when available, making it easier to identify stacks in multiplayer.
* **Bug Fixes**
  * Improved handling for offline or unspawned stacks so selection labels continue to display cleanly without extra details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->