### PR TITLE
Fix scoreboard showing 0 points at the start of multiplayer games

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,13 @@
+language: "en-US"
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: false
+  poem: false
+  review_status: false
+  review_details: false
+  auto_review:
+    enabled: true
+    drafts: false
+chat:
+  auto_reply: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,4 @@
 ## What's Changed
-- 
+<!-- List meaningful, user-facing changes as bullets below. These are used as release notes for end users, so write in simple, plain language and keep the description under 500 characters. Replace or remove any placeholder text before submitting. -->
+- First user-facing change
+- Second user-facing change

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,9 +109,24 @@ All C# files must start with the MPL 2.0 license header:
 
 ## Git Workflow
 - Main development branch: `develop`
-- PRs target `main` branch
+- All pull requests must go from the `develop` branch to the `main` branch
 - Use descriptive commit messages
 - Include tests for new features
+
+## Pull Request Policy
+
+All pull requests must follow these rules exactly:
+
+1. **Branch**: Always open PRs from `develop` to `main`.
+2. **Description length**: The PR description must be under 500 characters.
+3. **Audience**: Descriptions are used as release notes for end users. Write in simple, plain language — not developer jargon.
+4. **Format**: Use exactly this format:
+
+```markdown
+## What's Changed
+- First user-facing change
+- Second user-facing change
+```
 
 ## Resources
 - Unity Documentation: https://docs.unity3d.com/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,6 @@ All C# files must start with the MPL 2.0 license header:
 
 ## Git Workflow
 - Main development branch: `develop`
-- All pull requests must go from the `develop` branch to the `main` branch
 - Use descriptive commit messages
 - Include tests for new features
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ All pull requests must follow these rules exactly:
 1. **Branch**: Always open PRs from `develop` to `main`.
 2. **Description length**: The PR description must be under 500 characters.
 3. **Audience**: Descriptions are used as release notes for end users. Write in simple, plain language — not developer jargon.
-4. **Format**: Use exactly this format:
+4. **Format**: Use exactly this format, replacing the placeholder bullets with meaningful, user-facing changes. Remove any placeholder text before submitting:
 
 ```markdown
 ## What's Changed

--- a/Assets/Scripts/Cgs/Play/Multiplayer/CgsNetPlayer.cs
+++ b/Assets/Scripts/Cgs/Play/Multiplayer/CgsNetPlayer.cs
@@ -206,6 +206,7 @@ namespace Cgs.Play.Multiplayer
                 PlayController.Instance.SpawnUnspawnedZones();
                 RequestNameUpdate(PlayerPrefs.GetString(Scoreboard.PlayerNamePlayerPrefs,
                     Scoreboard.DefaultPlayerName));
+                RequestPointsUpdate(CardGameManager.Current.GameStartPointsCount);
                 RequestNewHand(CardDrawer.DefaultHandName);
                 ApplyPlayerTranslationServerRpc();
             }
@@ -326,6 +327,7 @@ namespace Cgs.Play.Multiplayer
                     break;
             }
 
+            RequestPointsUpdate(CardGameManager.Current.GameStartPointsCount);
             RequestNewHand(CardDrawer.DefaultHandName);
         }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# CLAUDE.md
+
+## Pull Request Policy
+
+All pull requests must follow these rules exactly:
+
+1. **Branch**: Always open PRs from `develop` to `main`.
+2. **Description length**: The PR description must be under 500 characters.
+3. **Audience**: Descriptions are used as release notes for end users. Write in simple, plain language — not developer jargon.
+4. **Format**: Use exactly this format:
+
+```markdown
+## What's Changed
+- First user-facing change
+- Second user-facing change
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ All pull requests must follow these rules exactly:
 1. **Branch**: Always open PRs from `develop` to `main`.
 2. **Description length**: The PR description must be under 500 characters.
 3. **Audience**: Descriptions are used as release notes for end users. Write in simple, plain language — not developer jargon.
-4. **Format**: Use exactly this format:
+4. **Format**: Use exactly this format, replacing the placeholder bullets with meaningful, user-facing changes. Remove any placeholder text before submitting:
 
 ```markdown
 ## What's Changed


### PR DESCRIPTION
## What's Changed
- Fixed a bug where the scoreboard showed 0 points for players at the start of a multiplayer game, even though the points counter showed the correct starting value. Starting points now appear correctly for everyone as soon as each player joins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Player points are now synchronized when joining a multiplayer game and when starting a new hand.

* **Documentation**
  * Updated pull request guidelines with specific branch requirements, a description length limit, plain-language expectations, and a standardized “What’s Changed” format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->