### PR TITLE
Fix multiplayer card sync and card zone drop order

### DIFF
--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardModel.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardModel.cs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Cgs.CardGameView.Viewer;
@@ -788,10 +789,24 @@ namespace Cgs.CardGameView.Multiplayer
         {
             Value.UnregisterDisplay(this);
             _id = newValue;
-            if (string.IsNullOrEmpty(_id) || !CardGameManager.Current.Cards.TryGetValue(_id, out var unityCard) ||
-                unityCard == null)
+            if (string.IsNullOrEmpty(_id))
             {
                 Debug.LogError($"ERROR: Id for {gameObject.name} changed to unknown card!");
+                return;
+            }
+
+            if (!CardGameManager.Current.Cards.TryGetValue(_id, out var unityCard) || unityCard == null)
+            {
+                if (CgsNetManager.Instance != null && CgsNetManager.Instance.IsOnline)
+                {
+                    // A joining client may not yet have downloaded and loaded the host's card game,
+                    // so wait for the card to load and then try again
+                    Debug.Log($"CardModel: Waiting for {_id} to load before applying it to {gameObject.name}...");
+                    StartCoroutine(WaitToResolveId(_id));
+                }
+                else
+                    Debug.LogError($"ERROR: Id for {gameObject.name} changed to unknown card!");
+
                 return;
             }
 
@@ -801,6 +816,15 @@ namespace Cgs.CardGameView.Multiplayer
             if (CardViewer.Instance != null && CardViewer.Instance.IsVisible &&
                 CardViewer.Instance.SelectedCardModel == this)
                 CardViewer.Instance.SelectedCardModel = this;
+        }
+
+        private IEnumerator WaitToResolveId(string cardId)
+        {
+            while (cardId.Equals(_id) && !CardGameManager.Current.Cards.ContainsKey(cardId))
+                yield return null;
+
+            if (cardId.Equals(_id))
+                OnChangeId(_id, _id);
         }
 
         [Rpc(SendTo.Server, InvokePermission = RpcInvokePermission.Everyone)]

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardStack.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardStack.cs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -114,7 +115,7 @@ namespace Cgs.CardGameView.Multiplayer
 
                 _cards = new List<UnityCard>();
                 foreach (var cardId in _cardIds)
-                    _cards.Add(CardGameManager.Current.Cards[cardId]);
+                    _cards.Add(LookupCard(cardId));
                 return _cards;
             }
             set
@@ -220,12 +221,60 @@ namespace Cgs.CardGameView.Multiplayer
             _name = _nameNetworkVariable.Value;
             _cards = new List<UnityCard>();
             foreach (var cardId in _cardIds)
-                _cards.Add(CardGameManager.Current.Cards[cardId]);
+                _cards.Add(LookupCard(cardId));
+            if (HasUnresolvedCardIds)
+                StartCoroutine(WaitToResolveCardIds());
             if (IsServer)
                 _isDeckSharedNetworkVariable.Value = _isDeckShared;
             _isDeckShared = _isDeckSharedNetworkVariable.Value;
             _isTopFaceup = _isTopFaceupNetworkVariable.Value;
         }
+
+        // A joining client may spawn card stacks before it finishes downloading and loading the host's card game,
+        // in which case card ids will temporarily fail to resolve and should be resolved later
+        private static UnityCard LookupCard(string cardId)
+        {
+            return CardGameManager.Current.Cards.TryGetValue(cardId, out var unityCard) && unityCard != null
+                ? unityCard
+                : UnityCard.Blank;
+        }
+
+        private bool HasUnresolvedCardIds
+        {
+            get
+            {
+                foreach (var cardId in _cardIds)
+                    if (!CardGameManager.Current.Cards.ContainsKey(cardId))
+                        return true;
+                return false;
+            }
+        }
+
+        private IEnumerator WaitToResolveCardIds()
+        {
+            if (_isResolvingCardIds)
+                yield break;
+
+            _isResolvingCardIds = true;
+            while (IsSpawned && HasUnresolvedCardIds)
+                yield return null;
+            _isResolvingCardIds = false;
+
+            if (!IsSpawned)
+                yield break;
+
+            Debug.Log($"CardStack: {name} resolved its card ids");
+            UnityCard.Blank.UnregisterDisplay(this);
+            _cards = new List<UnityCard>();
+            foreach (var cardId in _cardIds)
+                _cards.Add(LookupCard(cardId));
+            topCard.sprite = CardBackImageSprite;
+            if (IsTopFaceup)
+                TopCard?.RegisterDisplay(this);
+            SyncView();
+        }
+
+        private bool _isResolvingCardIds;
 
         protected override void OnStartPlayable()
         {
@@ -376,7 +425,7 @@ namespace Cgs.CardGameView.Multiplayer
             _cardIds.Clear();
             foreach (var cardId in cardIds)
             {
-                _cards.Add(CardGameManager.Current.Cards[cardId]);
+                _cards.Add(LookupCard(cardId));
                 _cardIds.Add(cardId);
             }
         }
@@ -385,7 +434,9 @@ namespace Cgs.CardGameView.Multiplayer
         {
             _cards = new List<UnityCard>();
             foreach (var cardId in _cardIds)
-                _cards.Add(CardGameManager.Current.Cards[cardId]);
+                _cards.Add(LookupCard(cardId));
+            if (HasUnresolvedCardIds)
+                StartCoroutine(WaitToResolveCardIds());
 
             if (IsTopFaceup)
             {
@@ -450,7 +501,7 @@ namespace Cgs.CardGameView.Multiplayer
         public void OwnerInsert(int index, string cardId)
         {
             Debug.Log($"CardStack: {name} insert {cardId} at {index} of {Cards.Count}");
-            _cards.Insert(index, CardGameManager.Current.Cards[cardId]);
+            _cards.Insert(index, LookupCard(cardId));
             if (CgsNetManager.Instance.IsOnline)
                 _cardIds.Insert(index, cardId);
             else
@@ -534,7 +585,7 @@ namespace Cgs.CardGameView.Multiplayer
             var cards = Cards.Select(card => card.Id).ToList();
             cards.Shuffle();
 
-            _cards = cards.Select(card => CardGameManager.Current.Cards[card]).ToList();
+            _cards = cards.Select(LookupCard).ToList();
 
             if (!CgsNetManager.Instance.IsOnline)
                 return;

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CgsNetPlayable.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CgsNetPlayable.cs
@@ -153,6 +153,22 @@ namespace Cgs.CardGameView.Multiplayer
         private Vector2 _size = Vector2.zero;
         private NetworkVariable<Vector2> _sizeNetworkVariable;
 
+        // Vertical and Horizontal CardZones order their cards by sibling index,
+        // which is not synced by Netcode, so it must be synced manually
+        public int SiblingIndex
+        {
+            get => IsSpawned ? _siblingIndexNetworkVariable.Value : transform.GetSiblingIndex();
+            set
+            {
+                if (value >= 0)
+                    transform.SetSiblingIndex(value);
+                if (IsSpawned && IsServer)
+                    _siblingIndexNetworkVariable.Value = value;
+            }
+        }
+
+        private NetworkVariable<int> _siblingIndexNetworkVariable;
+
         public PointerEventData CurrentPointerEventData { get; protected set; }
         public Dictionary<int, Vector2> PointerPositions { get; } = new();
         protected Dictionary<int, Vector2> PointerDragOffsets { get; } = new();
@@ -226,6 +242,9 @@ namespace Cgs.CardGameView.Multiplayer
             _sizeNetworkVariable = new NetworkVariable<Vector2>();
             _sizeNetworkVariable.OnValueChanged += OnChangeSize;
 
+            _siblingIndexNetworkVariable = new NetworkVariable<int>(-1);
+            _siblingIndexNetworkVariable.OnValueChanged += OnChangeSiblingIndex;
+
             OnAwakePlayable();
         }
 
@@ -284,6 +303,8 @@ namespace Cgs.CardGameView.Multiplayer
             var rectTransform = (RectTransform)transform;
             rectTransform.SetParent(containerTransform);
             rectTransform.localScale = Vector3.one;
+            if (IsSpawned && _siblingIndexNetworkVariable.Value >= 0)
+                rectTransform.SetSiblingIndex(_siblingIndexNetworkVariable.Value);
         }
 
         protected virtual void OnNetworkSpawnPlayable()
@@ -704,6 +725,13 @@ namespace Cgs.CardGameView.Multiplayer
             }
 
             Size = size;
+        }
+
+        [PublicAPI]
+        public void OnChangeSiblingIndex(int oldValue, int newValue)
+        {
+            if (newValue >= 0)
+                transform.SetSiblingIndex(newValue);
         }
 
         [PublicAPI]

--- a/Assets/Scripts/Cgs/Play/Multiplayer/CgsNetPlayer.cs
+++ b/Assets/Scripts/Cgs/Play/Multiplayer/CgsNetPlayer.cs
@@ -41,6 +41,30 @@ namespace Cgs.Play.Multiplayer
         }
     }
 
+    public struct CardSpawnParams : INetworkSerializable
+    {
+        // Public mutable fields are required so Netcode can (de)serialize them by ref,
+        // matching the existing DiscoveryResponseData DTO; hence S1104 is not applicable.
+#pragma warning disable S1104
+        public string CardId;
+        public Vector3 Position;
+        public Quaternion Rotation;
+        public bool IsFacedown;
+        public bool IsCardShared;
+        public int SiblingIndex;
+#pragma warning restore S1104
+
+        public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
+        {
+            serializer.SerializeValue(ref CardId);
+            serializer.SerializeValue(ref Position);
+            serializer.SerializeValue(ref Rotation);
+            serializer.SerializeValue(ref IsFacedown);
+            serializer.SerializeValue(ref IsCardShared);
+            serializer.SerializeValue(ref SiblingIndex);
+        }
+    }
+
     public class CgsNetPlayer : NetworkBehaviour
     {
         public const string GameSelectionErrorMessage = "The host has selected a game that is not available!";
@@ -687,8 +711,15 @@ namespace Cgs.Play.Multiplayer
             var isCardShared = cardModel.IsCardShared;
 
             if (cardZone.IsSpawned)
-                SpawnCardInZoneServerRpc(cardZone.gameObject, cardModel.Id, position, rotation, isFacedown,
-                    isCardShared, siblingIndex);
+                SpawnCardInZoneServerRpc(cardZone.gameObject, new CardSpawnParams
+                {
+                    CardId = cardModel.Id,
+                    Position = position,
+                    Rotation = rotation,
+                    IsFacedown = isFacedown,
+                    IsCardShared = isCardShared,
+                    SiblingIndex = siblingIndex
+                });
             else
             {
                 // An unspawned zone cannot be referenced on the server,
@@ -713,8 +744,15 @@ namespace Cgs.Play.Multiplayer
             bool isFacedown, bool isCardShared)
         {
             if (cardZone.IsSpawned)
-                SpawnCardInZoneServerRpc(cardZone.gameObject, cardId, position, rotation, isFacedown, isCardShared,
-                    -1);
+                SpawnCardInZoneServerRpc(cardZone.gameObject, new CardSpawnParams
+                {
+                    CardId = cardId,
+                    Position = position,
+                    Rotation = rotation,
+                    IsFacedown = isFacedown,
+                    IsCardShared = isCardShared,
+                    SiblingIndex = -1
+                });
             else
             {
                 // An unspawned zone cannot be referenced on the server, so spawn in the play area
@@ -724,13 +762,13 @@ namespace Cgs.Play.Multiplayer
 
         [ServerRpc]
         // ReSharper disable once MemberCanBeMadeStatic.Local
-        private void SpawnCardInZoneServerRpc(NetworkObjectReference container, string cardId, Vector3 position,
-            Quaternion rotation, bool isFacedown, bool isCardShared, int siblingIndex,
+        private void SpawnCardInZoneServerRpc(NetworkObjectReference container, CardSpawnParams cardSpawnParams,
             ServerRpcParams rpcParams = default)
         {
             if (!container.TryGet(out var containerObject))
             {
-                Debug.LogError($"[CgsNet Player] Failed to spawn {cardId}: Card zone container could not be resolved.");
+                Debug.LogError(
+                    $"[CgsNet Player] Failed to spawn {cardSpawnParams.CardId}: Card zone container could not be resolved.");
                 return;
             }
 
@@ -738,9 +776,10 @@ namespace Cgs.Play.Multiplayer
             if (containerObject.TryGetComponent<CardZone>(out var cardZone))
                 defaultAction = cardZone.DefaultAction.ToString();
 
-            PlayController.Instance.CreateCardModel(containerObject.gameObject, cardId, position, rotation, isFacedown,
-                isCardShared, new PlayController.CardModelCreationOptions(defaultAction,
-                    rpcParams.Receive.SenderClientId, siblingIndex));
+            PlayController.Instance.CreateCardModel(containerObject.gameObject, cardSpawnParams.CardId,
+                cardSpawnParams.Position, cardSpawnParams.Rotation, cardSpawnParams.IsFacedown,
+                cardSpawnParams.IsCardShared, new PlayController.CardModelCreationOptions(defaultAction,
+                    rpcParams.Receive.SenderClientId, cardSpawnParams.SiblingIndex));
         }
 
         [ServerRpc]

--- a/Assets/Scripts/Cgs/Play/Multiplayer/CgsNetPlayer.cs
+++ b/Assets/Scripts/Cgs/Play/Multiplayer/CgsNetPlayer.cs
@@ -675,6 +675,11 @@ namespace Cgs.Play.Multiplayer
         {
             var cardModelTransform = cardModel.transform;
             cardModelTransform.SetParent(cardZone.transform);
+            // Vertical and Horizontal zones order their cards by sibling index,
+            // which the local card got from its placeholder, so preserve it through the respawn
+            var siblingIndex = cardZone.Type is CardZoneType.Vertical or CardZoneType.Horizontal
+                ? cardModelTransform.GetSiblingIndex()
+                : -1;
             cardModel.SnapToGrid();
             var position = ((RectTransform) cardModelTransform).localPosition;
             var rotation = cardModelTransform.localRotation;
@@ -683,7 +688,7 @@ namespace Cgs.Play.Multiplayer
 
             if (cardZone.IsSpawned)
                 SpawnCardInZoneServerRpc(cardZone.gameObject, cardModel.Id, position, rotation, isFacedown,
-                    isCardShared);
+                    isCardShared, siblingIndex);
             else
             {
                 // An unspawned zone cannot be referenced on the server,
@@ -708,7 +713,8 @@ namespace Cgs.Play.Multiplayer
             bool isFacedown, bool isCardShared)
         {
             if (cardZone.IsSpawned)
-                SpawnCardInZoneServerRpc(cardZone.gameObject, cardId, position, rotation, isFacedown, isCardShared);
+                SpawnCardInZoneServerRpc(cardZone.gameObject, cardId, position, rotation, isFacedown, isCardShared,
+                    -1);
             else
             {
                 // An unspawned zone cannot be referenced on the server, so spawn in the play area
@@ -719,7 +725,8 @@ namespace Cgs.Play.Multiplayer
         [ServerRpc]
         // ReSharper disable once MemberCanBeMadeStatic.Local
         private void SpawnCardInZoneServerRpc(NetworkObjectReference container, string cardId, Vector3 position,
-            Quaternion rotation, bool isFacedown, bool isCardShared, ServerRpcParams rpcParams = default)
+            Quaternion rotation, bool isFacedown, bool isCardShared, int siblingIndex,
+            ServerRpcParams rpcParams = default)
         {
             if (!container.TryGet(out var containerObject))
             {
@@ -733,7 +740,7 @@ namespace Cgs.Play.Multiplayer
 
             PlayController.Instance.CreateCardModel(containerObject.gameObject, cardId, position, rotation, isFacedown,
                 isCardShared, new PlayController.CardModelCreationOptions(defaultAction,
-                    rpcParams.Receive.SenderClientId));
+                    rpcParams.Receive.SenderClientId, siblingIndex));
         }
 
         [ServerRpc]

--- a/Assets/Scripts/Cgs/Play/PlayController.cs
+++ b/Assets/Scripts/Cgs/Play/PlayController.cs
@@ -79,14 +79,17 @@ namespace Cgs.Play
 
         public readonly struct CardModelCreationOptions
         {
-            public CardModelCreationOptions(string defaultAction = "", ulong? ownerClientId = null)
+            public CardModelCreationOptions(string defaultAction = "", ulong? ownerClientId = null,
+                int? siblingIndex = null)
             {
                 DefaultAction = defaultAction;
                 OwnerClientId = ownerClientId;
+                SiblingIndex = siblingIndex;
             }
 
             public string DefaultAction { get; }
             public ulong? OwnerClientId { get; }
+            public int? SiblingIndex { get; }
         }
 
         public Transform stackViewers;
@@ -760,6 +763,8 @@ namespace Cgs.Play
             cardModel.Container = container;
             cardModel.Position = position;
             cardModel.Rotation = rotation;
+            if (options.SiblingIndex is >= 0)
+                cardModel.SiblingIndex = options.SiblingIndex.Value;
             cardModel.IsCardShared = isCardShared;
             cardModel.IsFacedown = isFacedown;
             if (!string.IsNullOrEmpty(options.DefaultAction) &&


### PR DESCRIPTION
## What's Changed
- Fixed an error that could occur when joining a multiplayer game: if the game had to be downloaded while cards were already on the table, those cards now appear correctly once the download finishes.
- Fixed cards dropped into a card zone during multiplayer landing at the end of the row instead of the spot where they were placed.