### PR TITLE
Animate card rotations

### DIFF
--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardModel.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardModel.cs
@@ -245,7 +245,11 @@ namespace Cgs.CardGameView.Multiplayer
                 if (targetRotation == 0)
                     targetRotation = CardGameManager.Current.CardRotationDefault;
                 if (targetRotation != 0)
-                    Rotation = Quaternion.Euler(0, 0, targetRotation);
+                {
+                    // This initial rotation is not a transition, so it must not animate
+                    transform.localRotation = Quaternion.Euler(0, 0, targetRotation);
+                    Rotation = transform.localRotation;
+                }
             }
 
             SetIsNameVisible(!IsFacedown && !IsSpawned);

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CgsNetPlayable.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CgsNetPlayable.cs
@@ -9,6 +9,7 @@ using Cgs.Menu;
 using Cgs.Play;
 using Cgs.UI;
 using JetBrains.Annotations;
+using PrimeTween;
 using Unity.Netcode;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -44,6 +45,9 @@ namespace Cgs.CardGameView.Multiplayer
         private static readonly Color SelectedHighlightColor = new(0.02f, 0.5f, 0.4f);
 
         private const string SelectableShaderName = "Shader Graphs/SelectableShader";
+
+        private const float RotationAnimationDuration = 0.25f;
+        private const float RotationAnimationMinDegrees = 1f;
 
         public CardZone ParentCardZone => transform.parent != null ? transform.parent.GetComponent<CardZone>() : null;
 
@@ -116,20 +120,26 @@ namespace Cgs.CardGameView.Multiplayer
 
         public Quaternion Rotation
         {
-            get => IsSpawned ? _rotationNetworkVariable.Value : transform.localRotation;
+            get => IsSpawned ? _rotationNetworkVariable.Value : _rotation;
             set
             {
-                transform.localRotation = value;
+                _rotation = value;
+                ApplyRotation(value);
                 if (!IsSpawned)
                     return;
                 if (IsServer)
-                    _rotationNetworkVariable.Value = transform.localRotation;
+                    _rotationNetworkVariable.Value = value;
                 else
-                    RequestUpdateRotation(transform.localRotation);
+                    RequestUpdateRotation(value);
             }
         }
 
+        // The visual transform may lag behind this logical rotation while ApplyRotation animates it
+        private Quaternion _rotation = Quaternion.identity;
         private NetworkVariable<Quaternion> _rotationNetworkVariable;
+
+        private Tween _rotationAnimation;
+        private Quaternion _rotationAnimationTarget;
 
         public Vector2 Size
         {
@@ -275,6 +285,7 @@ namespace Cgs.CardGameView.Multiplayer
 
             if (!Quaternion.identity.Equals(Rotation))
                 transform.localRotation = Rotation;
+            _rotation = transform.localRotation;
 
             if (IsServer && !Vector2.zero.Equals(((RectTransform)transform).sizeDelta))
             {
@@ -613,6 +624,7 @@ namespace Cgs.CardGameView.Multiplayer
             var previousDirection = (CurrentPointerEventData.position - CurrentPointerEventData.delta) - referencePoint;
             var currentDirection = CurrentPointerEventData.position - referencePoint;
             transform.Rotate(0, 0, Vector2.SignedAngle(previousDirection, currentDirection));
+            _rotation = transform.localRotation;
 
             if (IsSpawned && IsOwner)
                 RequestUpdateRotation(transform.localRotation);
@@ -706,7 +718,47 @@ namespace Cgs.CardGameView.Multiplayer
         [PublicAPI]
         public void OnChangeRotation(Quaternion oldValue, Quaternion newValue)
         {
-            transform.localRotation = newValue;
+            _rotation = newValue;
+            ApplyRotation(newValue);
+        }
+
+        protected virtual void ApplyRotation(Quaternion newRotation)
+        {
+            // Instant while the local player holds this playable, so drag rotation and its echoed network updates
+            // stay under the player's fingers instead of fighting a tween toward lagging values
+            if (!didStart || !gameObject.activeInHierarchy || PointerPositions.Count > 0 ||
+                Quaternion.Angle(transform.localRotation, newRotation) < RotationAnimationMinDegrees)
+            {
+                if (_rotationAnimation.isAlive)
+                    _rotationAnimation.Stop();
+                transform.localRotation = newRotation;
+                return;
+            }
+
+            if (_rotationAnimation.isAlive)
+            {
+                // The local setter already animates toward this target; the echoed network update is not a new turn
+                if (newRotation == _rotationAnimationTarget)
+                    return;
+                _rotationAnimation.Stop();
+            }
+
+            _rotationAnimationTarget = newRotation;
+            _rotationAnimation = Tween.LocalRotation(transform, newRotation, RotationAnimationDuration);
+        }
+
+        protected void FinishRotationAnimation()
+        {
+            if (!_rotationAnimation.isAlive)
+                return;
+            _rotationAnimation.Stop();
+            transform.localRotation = Rotation;
+        }
+
+        public override void OnDestroy()
+        {
+            FinishRotationAnimation();
+            base.OnDestroy();
         }
 
         private void RequestUpdateSize(Vector2 size)

--- a/openspec/changes/archive/2026-07-11-animate-card-actions/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-11-animate-card-actions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-11

--- a/openspec/changes/archive/2026-07-11-animate-card-actions/design.md
+++ b/openspec/changes/archive/2026-07-11-animate-card-actions/design.md
@@ -1,0 +1,63 @@
+# Animate Card Actions (Tap / Rotate) — Design
+
+## Context
+
+A card's rotation lives on the base class `CgsNetPlayable` (`Assets/Scripts/Cgs/CardGameView/Multiplayer/CgsNetPlayable.cs`). There are three paths that write the visual rotation, and all of them are instant today:
+
+1. **Local set** — the `Rotation` property setter (lines 117-129) writes `transform.localRotation = value` immediately, then commits to `_rotationNetworkVariable` (server) or `RequestUpdateRotation` → `UpdateRotationServerRpc` (client). `CardActionPanel.Rotate` and `CardActionPanel.Tap` (lines 136-177 of `CardActionPanel.cs`) both funnel through this setter.
+2. **Network update** — `OnChangeRotation(oldValue, newValue)` (lines 706-710) fires on every client via `_rotationNetworkVariable.OnValueChanged` and snaps `transform.localRotation = newValue`. This is the remote-client choke point, the exact analog of `OnChangeIsFacedown` that drives the flip animation.
+3. **Continuous drag** — the two-finger `Rotate()` gesture (lines 607-619) calls `transform.Rotate(...)` directly each frame and streams `RequestUpdateRotation`. The local dragger's transform is ahead of the network value.
+
+Initial state on spawn/join is applied by `ApplyPlayableNetworkVariables` writing `transform.localRotation` directly, bypassing both the setter and the callback, so joins and spawns naturally skip any hook placed on paths 1 and 2. `CardModel.OnNetworkSpawn` also sets an initial per-game rotation via the `Rotation` setter before `Start` completes.
+
+The precedent is the card flip animation in `CardModel.cs` (change `2026-07-11-card-flip-animation`): a PrimeTween `Sequence` with a duration constant, a stored handle for interruption, gating on `didStart && gameObject.activeInHierarchy && oldValue != newValue`, cleanup in `OnDestroy`, and a strict presentation-only rule — logical state and network sync update immediately, only the visuals lag. PrimeTween (`com.kyrylokuzyk.primetween`) is already a dependency.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Animate a card's rotation smoothly to its new angle when tapped, untapped, or rotated via the card action panel (buttons or input bindings), or when any other code path sets a discrete new rotation.
+- Animate a card stack's rotation the same way when rotated via the playable viewer's Rotate action.
+- Animate identically for local and remote players, driven by the same rotation change notifications.
+- Handle interruption: a new rotation during an animation retargets cleanly and settles exactly on the final rotation.
+- Skip animation when the change is not a user-visible transition (spawn, initial per-game rotation, joining in progress) and while the local player is drag-rotating the card.
+- Keep the animation purely presentational: `Rotation`, the network variable, and authorization are unchanged.
+
+**Non-Goals:**
+- No animation for the play mat (`RotateZoomableScrollRect` is not a playable and keeps its direct rotation).
+- No smoothing/interpolation redesign for continuous drag rotation streams; remote observers of a drag get whatever the retargeting tween produces.
+- No changes to tap/rotate semantics, `GameCardRotationDegrees`, or `allowsRotation` zone rules.
+
+## Decisions
+
+1. **Route all transform writes through a `protected virtual void ApplyRotation(Quaternion newRotation)` hook on `CgsNetPlayable`.** The `Rotation` setter and `OnChangeRotation` call the hook instead of writing `transform.localRotation` directly; the base implementation keeps today's instant write. The spawn-time network-variable application keeps its direct write so spawn/join never animates. Alternative considered: animate only in `OnChangeRotation` (pure flip pattern) — rejected because the local setter snaps the transform before the network round-trip, so the acting player would never see the animation. Alternative: animate in `CardActionPanel.Tap`/`Rotate` call sites — rejected because remote clients only see the network variable change, so the hook must live where both paths converge.
+
+   *Refinement during implementation:* the offline (`!IsSpawned`) `Rotation` getter previously read `transform.localRotation`, which would return mid-tween values once the transform animates (e.g., two quick Rotate actions would compound from a mid-tween angle and land off-step). A `_rotation` backing field now holds the logical rotation, mirroring the existing `_position` pattern; it is synced in the setter, `OnChangeRotation`, the drag `Rotate()` gesture, and at network spawn.
+
+2. **The base `ApplyRotation` implementation is the PrimeTween rotation tween.** `Tween.LocalRotation(transform, newRotation, RotationAnimationDuration)` from the current visual rotation toward the target, with `RotationAnimationDuration = 0.25f` matching the flip's total duration and `MainMenu.AnimationDuration`. The stored `Tween` handle enables interruption. Alternative considered: coroutine + `Quaternion.Lerp` — rejected for the same reasons as in the flip design (more code, lifecycle management).
+
+   *Refinement during implementation:* the tween initially lived in a `CardModel` override, but the user extended scope to card stacks rotated via the playable viewer. Since `CardStack.Rotation` flows through the same setter/`OnChangeRotation` paths and stacks set no rotation at `Start`, the tween (with all its gates) moved into the base implementation on `CgsNetPlayable`, so every playable — card, stack, die, counter — animates discrete rotation changes uniformly. Cleanup runs in a `CgsNetPlayable.OnDestroy` override, which subclass `OnDestroy` overrides already chain to.
+
+3. **Gate: animate only when `didStart && gameObject.activeInHierarchy` and the target differs from the current visual rotation by a meaningful angle (≈1°).** The `didStart` check skips pre-Start assignments (network spawn, zone placement at creation); the angle check makes same-value reasserts a no-op. Below-threshold or gated changes apply instantly via the base implementation. Because the game's default card rotation is assigned *inside* `Start()` (`OnStartPlayable`), where Unity may already report `didStart == true`, that call site pre-writes `transform.localRotation` before committing through the setter, so the angle gate guarantees the initial rotation never animates. An echoed network update that matches an in-flight tween's target is ignored rather than restarting the tween, so the acting client's animation is not stretched by the server round-trip.
+
+4. **Skip animation while the local player is drag-rotating the card.** During the two-finger `Rotate()` gesture the transform is directly manipulated each frame, and echoed `OnChangeRotation` callbacks carry values that lag the finger; tweening toward them would fight the drag and rotate backwards. When the card is being actively dragged by the local player (existing pointer/drag state on `CgsNetPlayable`/`CardModel`), the override applies rotation instantly. Remote observers of a drag still go through the tween path: each incoming update interrupts and retargets, which converges and reads as smoothing.
+
+5. **Interruption: stop the in-flight tween, then start a fresh tween from the current visual rotation to the newest target.** Mirrors `FinishFlipAnimation`: `if (_rotationAnimation.isAlive) _rotationAnimation.Stop();`. Unlike the flip there is no midpoint action to flush — the logical `Rotation` is already committed — so stopping mid-tween leaves the transform mid-way and the next tween (or `OnDestroy`) takes over. `OnDestroy` stops the tween; no snap needed since the object is going away, but any code path that must guarantee the final transform (e.g., before layout in a zone) can call a `FinishRotationAnimation` that stops the tween and snaps `transform.localRotation` to `Rotation`.
+
+6. **The tween and flip animations coexist without coordination.** Flip animates `localScale.x`; rotation animates `localRotation`. They touch disjoint transform channels, so a tap+flip in quick succession composes naturally.
+
+## Risks / Trade-offs
+
+- [Local dragger receives echoed network rotations mid-drag] → Decision 4 applies them instantly while dragging, preserving today's behavior exactly.
+- [Card moved between zones (hand ↔ play area) mid-tween; zone layout may set rotation] → Zone placement code that sets `Rotation` goes through the same hook; if the card is inactive or pre-Start it applies instantly, otherwise it retargets the tween. `FinishRotationAnimation` is available where an exact transform is required synchronously.
+- [Card destroyed mid-tween (deleted, stacked, taken)] → PrimeTween no-ops tweens on destroyed targets; `OnDestroy` stops the stored handle, matching the flip cleanup.
+- [Tween eases through intermediate angles that briefly misalign with grid/zone snapping visuals] → Presentation-only and ≤0.25s; logical position/rotation used by snapping reads the committed values, not the transform.
+- [`Quaternion` tween takes the short way around (e.g., 270° request animates −90°)] → Acceptable and arguably desirable for tap/untap; `GameCardRotationDegrees` steps are ≤180° in practice. Noted as expected behavior, not a defect.
+- [Remote smoothing of drag streams looks laggy] → Each update retargets a 0.25s tween from the current visual rotation, so error stays bounded within one tween duration; today's behavior is frame-stepped snapping, which is strictly worse.
+
+## Migration Plan
+
+Purely additive visual change; no data or protocol migration. Rollback = revert the commit.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-07-11-animate-card-actions/proposal.md
+++ b/openspec/changes/archive/2026-07-11-animate-card-actions/proposal.md
@@ -1,0 +1,33 @@
+# Animate Card Actions (Tap / Rotate)
+
+## Why
+
+When a player taps or rotates a card via the card action panel, the card's rotation changes instantly, snapping to the new angle with no visual transition. This feels abrupt and is easy to miss, especially in multiplayer where another player taps a card. Following the recently added card flip animation, a brief rotation tween makes tap/rotate state changes obvious and gives the game a more polished, tabletop-like feel.
+
+## What Changes
+
+- When a card's rotation changes by a discrete action — Tap or Rotate from the card action panel, their keyboard/gamepad input bindings, or any other code path that sets a card's rotation to a new angle — the card smoothly animates to the new rotation instead of snapping.
+- Card stacks rotated via the playable viewer's Rotate action animate the same way; the animation lives on the shared playable base class, so all playables (cards, stacks, dice, counters) rotate smoothly on discrete changes.
+- The animation plays for all players in multiplayer: it is driven by the existing rotation change notification, so remote clients see the same rotation tween.
+- Rotation changes that are not user-visible transitions (initial spawn, cards created with a default rotation, joining a game in progress) do not animate — the card simply appears at its correct rotation.
+- Continuous two-finger drag rotation keeps its current direct, unanimated behavior for the player performing the drag; the card must remain responsive under the player's fingers.
+- Rapid repeated taps/rotates interrupt any in-progress animation and settle on the final rotation.
+- The logical rotation state and its network synchronization update immediately, as today; only the visual transform is animated.
+
+## Capabilities
+
+### New Capabilities
+
+- `card-rotation-animation`: Visual rotation transition when a card or card stack's rotation changes (tap, untap, rotate), including interruption handling, no-animation cases (spawn/initial state/local drag), and presentation-only guarantees.
+
+### Modified Capabilities
+
+<!-- None: no existing spec's requirements change. Rotation state sync behavior is unchanged; only its visual presentation is enhanced. Tap/Rotate action semantics in CardActionPanel are unchanged. -->
+
+## Impact
+
+- `Assets/Scripts/Cgs/CardGameView/Multiplayer/CgsNetPlayable.cs`: the `Rotation` setter and `OnChangeRotation` currently write `transform.localRotation` instantly; the transform write goes through an `ApplyRotation` hook that tweens the rotation with PrimeTween, mirroring the existing flip animation pattern (duration constant, stored tween handle, interruption handling, `OnDestroy` cleanup). All playables inherit it.
+- `Assets/Scripts/Cgs/CardGameView/Multiplayer/CardModel.cs`: the game-default rotation applied at `Start` is pre-written to the transform so it never animates.
+- `Assets/Scripts/Cgs/CardGameView/Viewer/CardActionPanel.cs` and `PlayableViewer.cs`: no changes — Tap, Rotate, and Rotate Stack already funnel through the `Rotation` property.
+- No new dependencies: PrimeTween is already used for the card flip animation and main menu carousel.
+- No network protocol changes: `_rotationNetworkVariable` and its RPC are untouched.

--- a/openspec/changes/archive/2026-07-11-animate-card-actions/specs/card-rotation-animation/spec.md
+++ b/openspec/changes/archive/2026-07-11-animate-card-actions/specs/card-rotation-animation/spec.md
@@ -1,0 +1,72 @@
+# card-rotation-animation Specification
+
+## ADDED Requirements
+
+### Requirement: Card rotation changes are animated
+When a visible card's rotation is changed to a new angle by a discrete action (such as Tap or Rotate from the card action panel or their input bindings), the card SHALL smoothly animate from its current rotation to the new rotation instead of snapping instantly.
+
+#### Scenario: Rotating a card
+- **WHEN** a player uses the card action panel's Rotate action on a card in the play area
+- **THEN** the card smoothly animates to its new rotation over a brief duration
+
+#### Scenario: Tapping a card
+- **WHEN** a player uses the card action panel's Tap action on an untapped card
+- **THEN** the card smoothly animates from its untapped rotation to its tapped rotation
+
+#### Scenario: Untapping a card
+- **WHEN** a player uses the card action panel's Tap action on a tapped card
+- **THEN** the card smoothly animates back to its untapped rotation
+
+### Requirement: Card stack rotation changes are animated
+When a visible card stack's rotation is changed to a new angle by a discrete action (such as Rotate from the playable viewer or its input binding), the stack SHALL smoothly animate from its current rotation to the new rotation instead of snapping instantly, with the same gating, interruption, and presentation-only behavior as cards.
+
+#### Scenario: Rotating a card stack
+- **WHEN** a player uses the playable viewer's Rotate action on a card stack in the play area
+- **THEN** the stack smoothly animates to its new rotation over a brief duration
+
+### Requirement: Remote rotation changes are animated
+When a card's rotation changes because another player tapped or rotated it in a multiplayer game, the observing client SHALL play the same rotation animation as the client that initiated the change.
+
+#### Scenario: Another player taps a card
+- **WHEN** player A taps a card in a multiplayer game
+- **THEN** player B sees the card smoothly animate to its tapped rotation
+
+### Requirement: Non-transition rotation states are not animated
+Cards SHALL appear directly at their correct rotation, without animation, when the rotation is being applied for the first time rather than changed by a player.
+
+#### Scenario: Card spawned with a rotation
+- **WHEN** a card is created already rotated (e.g., a game's default card rotation or a card placed in a rotated zone)
+- **THEN** the card appears at that rotation immediately with no animation
+
+#### Scenario: Client joins a game in progress
+- **WHEN** a client joins a multiplayer game containing tapped or rotated cards
+- **THEN** those cards appear at their current rotations immediately with no animation
+
+#### Scenario: Rotation reasserted without change
+- **WHEN** a card's rotation is set to the value it already has
+- **THEN** no rotation animation plays
+
+### Requirement: Drag rotation stays direct for the dragging player
+While the local player is rotating a card with the continuous drag gesture, the card SHALL follow the gesture directly without animation, exactly as it does today.
+
+#### Scenario: Two-finger drag rotation
+- **WHEN** a player rotates a card using the two-finger drag gesture
+- **THEN** the card's rotation tracks the gesture immediately, with no tween lag, including when echoed network updates arrive mid-drag
+
+### Requirement: Interrupted rotation animations settle on the final rotation
+If a card's rotation changes while a rotation animation is still playing, the in-progress animation SHALL be interrupted and the card SHALL animate from its current visual rotation to the newest target rotation, settling exactly at that rotation.
+
+#### Scenario: Rapid repeated rotates
+- **WHEN** a player triggers Rotate twice in quick succession
+- **THEN** the first animation is interrupted and the card animates to and settles exactly at the final rotation
+
+### Requirement: Animation is presentation-only
+The rotation animation SHALL NOT delay or alter the card's logical rotation state, network synchronization, or authorization checks; only the visual transform changes on a delay.
+
+#### Scenario: Logical rotation updates immediately
+- **WHEN** a card is tapped
+- **THEN** any game logic reading the card's rotation observes the new value immediately, even while the animation is still playing
+
+#### Scenario: Card destroyed mid-animation
+- **WHEN** a card is deleted or stacked while its rotation animation is playing
+- **THEN** no errors occur and the animation is discarded with the card

--- a/openspec/changes/archive/2026-07-11-animate-card-actions/tasks.md
+++ b/openspec/changes/archive/2026-07-11-animate-card-actions/tasks.md
@@ -1,0 +1,28 @@
+# Animate Card Actions (Tap / Rotate) — Tasks
+
+## 1. Rotation hook in CgsNetPlayable
+
+- [x] 1.1 Add `protected virtual void ApplyRotation(Quaternion newRotation)` to `CgsNetPlayable.cs` with the current instant behavior (`transform.localRotation = newRotation`)
+- [x] 1.2 Change the `Rotation` property setter to call `ApplyRotation(value)` instead of writing `transform.localRotation` directly, keeping the network-commit logic unchanged
+- [x] 1.3 Change `OnChangeRotation` to call `ApplyRotation(newValue)` instead of writing `transform.localRotation` directly
+- [x] 1.4 Confirm `ApplyPlayableNetworkVariables` keeps its direct `transform.localRotation` write so spawn/join never animates
+
+## 2. Rotation tween in CardModel
+
+- [x] 2.1 Add `RotationAnimationDuration = 0.25f` constant and a stored `Tween _rotationAnimation` field to `CardModel.cs`, near the existing flip animation members
+- [x] 2.2 Override `ApplyRotation` in `CardModel`: when `didStart && gameObject.activeInHierarchy`, the local player is not drag-rotating this card, and the target differs from the current visual rotation by ≥ ~1°, stop any in-flight rotation tween and start `Tween.LocalRotation(transform, newRotation, RotationAnimationDuration)`; otherwise fall back to the base instant write
+- [x] 2.3 Add `FinishRotationAnimation()` that stops the stored tween (if alive) and snaps `transform.localRotation` to `Rotation`; call it from `OnDestroy` alongside `FinishFlipAnimation`
+- [x] 2.4 Verify the drag-rotation gate uses the existing pointer/drag state (the two-finger `Rotate()` path) so echoed network updates mid-drag apply instantly for the dragging player
+
+## 3. Verification
+
+- [x] 3.1 In the play area, use the card action panel to Tap, untap, and Rotate a card: the card animates smoothly to each rotation, and rapid repeated actions retarget cleanly and settle exactly on the final angle
+- [x] 3.2 Verify no animation plays on non-transitions: card spawn with a game default rotation, dealing/placing cards into rotated zones, and rejoining a multiplayer game with tapped cards
+- [x] 3.3 In a multiplayer session, verify the observing client sees the tap/rotate animation, drag-rotation stays direct for the dragger, and tap+flip in quick succession compose without visual glitches
+- [x] 3.4 Verify deleting or stacking a card mid-animation produces no errors, and run the project's existing edit/play mode tests
+
+## 4. Extend to card stacks (playable viewer Rotate)
+
+- [x] 4.1 Move the rotation tween (constants, tween handle, gates, `FinishRotationAnimation`) from the `CardModel` override into the base `CgsNetPlayable.ApplyRotation`, so all playables animate discrete rotation changes
+- [x] 4.2 Add a `CgsNetPlayable.OnDestroy` override that finishes the rotation animation; remove the now-redundant `CardModel` members
+- [x] 4.3 In the play area, use the playable viewer's Rotate action on a card stack: the stack animates smoothly, and drag-rotation of stacks stays direct

--- a/openspec/specs/card-rotation-animation/spec.md
+++ b/openspec/specs/card-rotation-animation/spec.md
@@ -1,0 +1,73 @@
+# card-rotation-animation Specification
+
+## Purpose
+Add a rotation animation when a card or card stack's rotation changes (tap, untap, rotate), including interruption handling, no-animation cases (spawn/initial state/local drag), and presentation-only guarantees, so rotation changes are visually clear in both solo and multiplayer.
+## Requirements
+### Requirement: Card rotation changes are animated
+When a visible card's rotation is changed to a new angle by a discrete action (such as Tap or Rotate from the card action panel or their input bindings), the card SHALL smoothly animate from its current rotation to the new rotation instead of snapping instantly.
+
+#### Scenario: Rotating a card
+- **WHEN** a player uses the card action panel's Rotate action on a card in the play area
+- **THEN** the card smoothly animates to its new rotation over a brief duration
+
+#### Scenario: Tapping a card
+- **WHEN** a player uses the card action panel's Tap action on an untapped card
+- **THEN** the card smoothly animates from its untapped rotation to its tapped rotation
+
+#### Scenario: Untapping a card
+- **WHEN** a player uses the card action panel's Tap action on a tapped card
+- **THEN** the card smoothly animates back to its untapped rotation
+
+### Requirement: Card stack rotation changes are animated
+When a visible card stack's rotation is changed to a new angle by a discrete action (such as Rotate from the playable viewer or its input binding), the stack SHALL smoothly animate from its current rotation to the new rotation instead of snapping instantly, with the same gating, interruption, and presentation-only behavior as cards.
+
+#### Scenario: Rotating a card stack
+- **WHEN** a player uses the playable viewer's Rotate action on a card stack in the play area
+- **THEN** the stack smoothly animates to its new rotation over a brief duration
+
+### Requirement: Remote rotation changes are animated
+When a card's rotation changes because another player tapped or rotated it in a multiplayer game, the observing client SHALL play the same rotation animation as the client that initiated the change.
+
+#### Scenario: Another player taps a card
+- **WHEN** player A taps a card in a multiplayer game
+- **THEN** player B sees the card smoothly animate to its tapped rotation
+
+### Requirement: Non-transition rotation states are not animated
+Cards SHALL appear directly at their correct rotation, without animation, when the rotation is being applied for the first time rather than changed by a player.
+
+#### Scenario: Card spawned with a rotation
+- **WHEN** a card is created already rotated (e.g., a game's default card rotation or a card placed in a rotated zone)
+- **THEN** the card appears at that rotation immediately with no animation
+
+#### Scenario: Client joins a game in progress
+- **WHEN** a client joins a multiplayer game containing tapped or rotated cards
+- **THEN** those cards appear at their current rotations immediately with no animation
+
+#### Scenario: Rotation reasserted without change
+- **WHEN** a card's rotation is set to the value it already has
+- **THEN** no rotation animation plays
+
+### Requirement: Drag rotation stays direct for the dragging player
+While the local player is rotating a card with the continuous drag gesture, the card SHALL follow the gesture directly without animation, exactly as it does today.
+
+#### Scenario: Two-finger drag rotation
+- **WHEN** a player rotates a card using the two-finger drag gesture
+- **THEN** the card's rotation tracks the gesture immediately, with no tween lag, including when echoed network updates arrive mid-drag
+
+### Requirement: Interrupted rotation animations settle on the final rotation
+If a card's rotation changes while a rotation animation is still playing, the in-progress animation SHALL be interrupted and the card SHALL animate from its current visual rotation to the newest target rotation, settling exactly at that rotation.
+
+#### Scenario: Rapid repeated rotates
+- **WHEN** a player triggers Rotate twice in quick succession
+- **THEN** the first animation is interrupted and the card animates to and settles exactly at the final rotation
+
+### Requirement: Animation is presentation-only
+The rotation animation SHALL NOT delay or alter the card's logical rotation state, network synchronization, or authorization checks; only the visual transform changes on a delay.
+
+#### Scenario: Logical rotation updates immediately
+- **WHEN** a card is tapped
+- **THEN** any game logic reading the card's rotation observes the new value immediately, even while the animation is still playing
+
+#### Scenario: Card destroyed mid-animation
+- **WHEN** a card is deleted or stacked while its rotation animation is playing
+- **THEN** no errors occur and the animation is discarded with the card


### PR DESCRIPTION
## What's Changed
- Cards now rotate with a smooth animation when tapped, untapped, or rotated
- Card stacks also rotate smoothly when rotated
- In multiplayer, other players see the same smooth rotation