### PR TITLE
Fix facedown when moving cards with the Move Menu

### DIFF
--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardZone.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardZone.cs
@@ -259,14 +259,27 @@ namespace Cgs.CardGameView.Multiplayer
 
         public void AddCard(Card card)
         {
+            AddCard(card, false);
+        }
+
+        public void AddCard(Card card, bool isFacedown)
+        {
+            // Apply this zone's face preference, same as when a card is dragged and dropped into the zone
+            isFacedown = DefaultFace switch
+            {
+                FacePreference.Down => true,
+                FacePreference.Up => false,
+                _ => isFacedown
+            } && !card.IsBackFaceCard;
+
             var isCardShared = SharePreference.Share == CardGameManager.Current.DeckSharePreference;
             if (CgsNetManager.Instance.IsOnline && CgsNetManager.Instance.LocalPlayer != null)
                 CgsNetManager.Instance.LocalPlayer.RequestNewCardInZone(this, card.Id, Vector2.zero,
-                    Quaternion.identity, false, isCardShared);
+                    Quaternion.identity, isFacedown, isCardShared);
             else
             {
                 var cardModel = PlayController.Instance.CreateCardModel(gameObject, card.Id, Vector2.zero,
-                    Quaternion.identity, false, isCardShared);
+                    Quaternion.identity, isFacedown, isCardShared);
                 OnAdd(cardModel);
             }
         }

--- a/Assets/Scripts/Cgs/Play/MoveMenu.cs
+++ b/Assets/Scripts/Cgs/Play/MoveMenu.cs
@@ -177,7 +177,19 @@ namespace Cgs.Play
                 return;
             }
 
-            _selectedCardContainer.AddCard(_selectedCardModel.Value);
+            switch (_selectedCardContainer)
+            {
+                case CardZone cardZone:
+                    cardZone.AddCard(_selectedCardModel.Value, _selectedCardModel.IsFacedown);
+                    break;
+                case PlayController playController:
+                    playController.AddCard(_selectedCardModel.Value, _selectedCardModel.IsFacedown);
+                    break;
+                default:
+                    _selectedCardContainer.AddCard(_selectedCardModel.Value);
+                    break;
+            }
+
             _selectedCardModel.RequestDelete();
 
             Hide();

--- a/Assets/Scripts/Cgs/Play/PlayController.cs
+++ b/Assets/Scripts/Cgs/Play/PlayController.cs
@@ -705,13 +705,20 @@ namespace Cgs.Play
 
         public void AddCard(Card card)
         {
+            AddCard(card, false);
+        }
+
+        public void AddCard(Card card, bool isFacedown)
+        {
+            isFacedown = isFacedown && !card.IsBackFaceCard;
+
             if (CgsNetManager.Instance.IsOnline && CgsNetManager.Instance.LocalPlayer != null)
-                CgsNetManager.Instance.LocalPlayer.RequestNewCard(card.Id, Vector2.zero, Quaternion.identity, false,
-                    SharePreference.Share == CardGameManager.Current.DeckSharePreference);
+                CgsNetManager.Instance.LocalPlayer.RequestNewCard(card.Id, Vector2.zero, Quaternion.identity,
+                    isFacedown, SharePreference.Share == CardGameManager.Current.DeckSharePreference);
             else
             {
                 var cardModel = CreateCardModel(playAreaCardZone.gameObject, card.Id, Vector2.zero, Quaternion.identity,
-                    false, SharePreference.Share == CardGameManager.Current.DeckSharePreference);
+                    isFacedown, SharePreference.Share == CardGameManager.Current.DeckSharePreference);
                 AddCardToPlayArea(playAreaCardZone, cardModel);
             }
         }


### PR DESCRIPTION
## What's Changed
- Cards moved with the Move Menu now stay facedown when moved to Play or to a zone, just like when dragging and dropping
- Zones set to face-down or face-up now apply that setting to cards moved in with the Move Menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)