### PR TITLE
Fix stale game play zones after updating a game

### DIFF
--- a/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
+++ b/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCardGame.cs
@@ -166,6 +166,7 @@ namespace FinolDigital.Cgs.Json.Unity
 
         public void ClearDefinitionLists()
         {
+            CardBackFaceImageUrls.Clear();
             CardProperties.Clear();
             DeckPlayCards.Clear();
             DeckUrls.Clear();
@@ -173,6 +174,9 @@ namespace FinolDigital.Cgs.Json.Unity
             Extras.Clear();
             GameBoardCards.Clear();
             GameBoardUrls.Clear();
+            GamePlayDeckPositions.Clear();
+            GamePlayZones.Clear();
+            GameStartDecks.Clear();
         }
 
         public void ReadProperties()


### PR DESCRIPTION
## What's Changed
- Fixed an issue where updating a game could leave behind old play zones that were removed from the game definition