### PR TITLE
Fix scroll wheel speed in the Microsoft Store version

### DIFF
--- a/Assets/Prefabs/EventSystem.prefab
+++ b/Assets/Prefabs/EventSystem.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 7182009478751603585}
   - component: {fileID: 7182009478751603584}
   - component: {fileID: 3775878152347106039}
+  - component: {fileID: 3775878152347106040}
   m_Layer: 0
   m_Name: EventSystem
   m_TagString: Untagged
@@ -90,3 +91,15 @@ MonoBehaviour:
   m_PointerBehavior: 0
   m_CursorLockBehavior: 0
   m_ScrollDeltaPerTick: 6
+--- !u!114 &3775878152347106040
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7182009478751603590}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa63d96bd43b436abaef7b3060f18dea, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:

--- a/Assets/Scripts/Cgs/UI/UwpScrollSensitivityFix.cs
+++ b/Assets/Scripts/Cgs/UI/UwpScrollSensitivityFix.cs
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+using UnityEngine;
+using UnityEngine.InputSystem.UI;
+
+namespace Cgs.UI
+{
+    [RequireComponent(typeof(InputSystemUIInputModule))]
+    public class UwpScrollSensitivityFix : MonoBehaviour
+    {
+        // Windows reports raw mouse wheel deltas of +/-120 per tick.
+        // The Input System normalizes this to +/-1 on StandaloneWindows,
+        // but not on UWP/WSA, so rescale to match the other platforms.
+        private const float WindowsScrollDeltaPerTick = 120f;
+
+#if UNITY_WSA && !UNITY_EDITOR
+        private void Awake()
+        {
+            var inputModule = GetComponent<InputSystemUIInputModule>();
+            inputModule.scrollDeltaPerTick /= WindowsScrollDeltaPerTick;
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/Cgs/UI/UwpScrollSensitivityFix.cs.meta
+++ b/Assets/Scripts/Cgs/UI/UwpScrollSensitivityFix.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa63d96bd43b436abaef7b3060f18dea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## What's Changed
- Fixed the mouse wheel scrolling way too fast in the Microsoft Store (Windows) version, such as when browsing cards in the Cards Explorer. Scrolling now feels the same as on other platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)