### PR TITLE
Move Menu scrolling, deck loading, and card image fixes

### DIFF
--- a/Assets/Scripts/Cgs/UI/SelectionPanel.cs
+++ b/Assets/Scripts/Cgs/UI/SelectionPanel.cs
@@ -37,20 +37,32 @@ namespace Cgs.UI
 
         private float GetContentHeight(int optionCount)
         {
-            var height = selectionTemplate.rect.height * optionCount;
             if (!selectionContent.TryGetComponent<LayoutGroup>(out var layoutGroup))
-                return height;
+                return selectionTemplate.rect.height * optionCount;
 
-            height += layoutGroup.padding.vertical;
-            var spacing = layoutGroup switch
+            var rowCount = optionCount;
+            var spacing = 0f;
+            switch (layoutGroup)
             {
-                FlowLayoutGroup flowLayoutGroup => flowLayoutGroup.spacing.y,
-                HorizontalOrVerticalLayoutGroup horizontalOrVerticalLayoutGroup =>
-                    horizontalOrVerticalLayoutGroup.spacing,
-                _ => 0f
-            };
-            if (optionCount > 1)
-                height += spacing * (optionCount - 1);
+                case FlowLayoutGroup flowLayoutGroup:
+                    spacing = flowLayoutGroup.spacing.y;
+                    var itemWidth = selectionTemplate.rect.width + flowLayoutGroup.spacing.x;
+                    if (flowLayoutGroup.horizontal && itemWidth > 0)
+                    {
+                        var availableWidth = selectionContent.rect.width - layoutGroup.padding.horizontal;
+                        var itemsPerRow = Mathf.Max(1, Mathf.FloorToInt((availableWidth + 0.001f) / itemWidth));
+                        rowCount = Mathf.CeilToInt(optionCount / (float) itemsPerRow);
+                    }
+
+                    break;
+                case VerticalLayoutGroup verticalLayoutGroup:
+                    spacing = verticalLayoutGroup.spacing;
+                    break;
+            }
+
+            var height = selectionTemplate.rect.height * rowCount + layoutGroup.padding.vertical;
+            if (rowCount > 1)
+                height += spacing * (rowCount - 1);
             return height;
         }
 

--- a/Assets/Scripts/Cgs/UI/SelectionPanel.cs
+++ b/Assets/Scripts/Cgs/UI/SelectionPanel.cs
@@ -35,6 +35,25 @@ namespace Cgs.UI
             selectionContent.sizeDelta = new Vector2(selectionContent.sizeDelta.x, 0);
         }
 
+        private float GetContentHeight(int optionCount)
+        {
+            var height = selectionTemplate.rect.height * optionCount;
+            if (!selectionContent.TryGetComponent<LayoutGroup>(out var layoutGroup))
+                return height;
+
+            height += layoutGroup.padding.vertical;
+            var spacing = layoutGroup switch
+            {
+                FlowLayoutGroup flowLayoutGroup => flowLayoutGroup.spacing.y,
+                HorizontalOrVerticalLayoutGroup horizontalOrVerticalLayoutGroup =>
+                    horizontalOrVerticalLayoutGroup.spacing,
+                _ => 0f
+            };
+            if (optionCount > 1)
+                height += spacing * (optionCount - 1);
+            return height;
+        }
+
         protected void Rebuild<TKey, TValue>(IDictionary<TKey, TValue> options, OnSelectDelegate<TKey> select,
             TKey current)
         {
@@ -43,8 +62,7 @@ namespace Cgs.UI
 
             Toggles.Clear();
             selectionContent.DestroyAllChildren();
-            selectionContent.sizeDelta =
-                new Vector2(selectionContent.sizeDelta.x, selectionTemplate.rect.height * options.Count);
+            selectionContent.sizeDelta = new Vector2(selectionContent.sizeDelta.x, GetContentHeight(options.Count));
 
             var currentSelectionIndex = -1;
             var i = 0;

--- a/Assets/Scripts/FinolDigital.Cgs.Json.Unity/ImageQueueService.cs
+++ b/Assets/Scripts/FinolDigital.Cgs.Json.Unity/ImageQueueService.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using UnityEngine;
 using UnityExtensionMethods;
 #if !UNITY_WEBGL
+using System;
 using System.IO;
 #endif
 
@@ -47,32 +48,46 @@ namespace FinolDigital.Cgs.Json.Unity
         {
             Sprite newSprite = null;
 
-#if !UNITY_WEBGL
-            yield return UnityFileMethods.RunOutputCoroutine<Sprite>(
-                UnityFileMethods.CreateAndOutputSpriteFromImageFile(unityCard.ImageFilePath,
-                    unityCard.ImageWebUrl.Replace(" ", "%20"))
-                , output => newSprite = output);
-            if (newSprite == null)
-                Debug.LogWarning(
-                    $"Failed to load image for card: {unityCard.Name} ({unityCard.Id}) at {unityCard.ImageFilePath}");
-            var fileInfo = new FileInfo(unityCard.ImageFilePath);
-            if (fileInfo.Exists && fileInfo.Length > MaxImageFileSizeBytes)
-                Debug.LogWarning(string.Format(SizeWarningMessage, unityCard.Name, unityCard.Id));
-#else
-            var url = unityCard.ImageWebUrl;
-            if (url.StartsWith("https://") && !url.StartsWith("https://cgs.games/api/proxy/"))
+            try
             {
-                url = "https://cgs.games/api/proxy/" + url[8..];
-                Debug.Log("CGS Games WebGL url : " + url);
-            }
+#if !UNITY_WEBGL
+                yield return UnityFileMethods.RunOutputCoroutine<Sprite>(
+                    UnityFileMethods.CreateAndOutputSpriteFromImageFile(unityCard.ImageFilePath,
+                        unityCard.ImageWebUrl.Replace(" ", "%20"))
+                    , output => newSprite = output);
+                if (newSprite == null)
+                    Debug.LogWarning(
+                        $"Failed to load image for card: {unityCard.Name} ({unityCard.Id}) at {unityCard.ImageFilePath}");
+                try
+                {
+                    var fileInfo = new FileInfo(unityCard.ImageFilePath);
+                    if (fileInfo.Exists && fileInfo.Length > MaxImageFileSizeBytes)
+                        Debug.LogWarning(string.Format(SizeWarningMessage, unityCard.Name, unityCard.Id));
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning(
+                        $"Failed to check image file size for card: {unityCard.Name} ({unityCard.Id}): {e}");
+                }
+#else
+                var url = unityCard.ImageWebUrl;
+                if (url.StartsWith("https://") && !url.StartsWith("https://cgs.games/api/proxy/"))
+                {
+                    url = "https://cgs.games/api/proxy/" + url[8..];
+                    Debug.Log("CGS Games WebGL url : " + url);
+                }
 
-            yield return UnityFileMethods.RunOutputCoroutine<Sprite>(
-                UnityFileMethods.CreateAndOutputSpriteFromImageFile(url)
-                , output => newSprite = output);
+                yield return UnityFileMethods.RunOutputCoroutine<Sprite>(
+                    UnityFileMethods.CreateAndOutputSpriteFromImageFile(url)
+                    , output => newSprite = output);
 #endif
 
-            unityCard.OnLoadImage(newSprite);
-            _concurrentQueueCount--;
+                unityCard.OnLoadImage(newSprite);
+            }
+            finally
+            {
+                _concurrentQueueCount--;
+            }
         }
     }
 }

--- a/Assets/Scripts/FinolDigital.Cgs.Json.Unity/ImageQueueService.cs
+++ b/Assets/Scripts/FinolDigital.Cgs.Json.Unity/ImageQueueService.cs
@@ -81,12 +81,11 @@ namespace FinolDigital.Cgs.Json.Unity
                     UnityFileMethods.CreateAndOutputSpriteFromImageFile(url)
                     , output => newSprite = output);
 #endif
-
-                unityCard.OnLoadImage(newSprite);
             }
             finally
             {
                 _concurrentQueueCount--;
+                unityCard.OnLoadImage(newSprite);
             }
         }
     }

--- a/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityDeck.cs
+++ b/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityDeck.cs
@@ -244,16 +244,16 @@ namespace FinolDigital.Cgs.Json.Unity
                     }
                 }
 
-if (tokens.Count == 1 && !SourceGame.CardNameIsUnique && string.IsNullOrEmpty(cardId)
-    && ((UnityCardGame) SourceGame).Cards.ContainsKey(tokens[0]))
-{
-    cardId = tokens[0];
-    cardName = string.Empty;
-}
-else
-{
-    cardName = tokens.Count > 0 ? string.Join(" ", tokens.ToArray()) : string.Empty;
-}
+                if (tokens.Count > 0 && !SourceGame.CardNameIsUnique && string.IsNullOrEmpty(cardId)
+                    && ((UnityCardGame) SourceGame).Cards.ContainsKey(tokens[0]))
+                {
+                    cardId = tokens[0];
+                    cardName = string.Empty;
+                }
+                else
+                {
+                    cardName = tokens.Count > 0 ? string.Join(" ", tokens.ToArray()) : string.Empty;
+                }
             }
 
             var cards = ((UnityCardGame) SourceGame).FilterCards(new CardSearchFilters()

--- a/Assets/Scripts/UnityExtensionMethods/UnityFileMethods.cs
+++ b/Assets/Scripts/UnityExtensionMethods/UnityFileMethods.cs
@@ -335,34 +335,57 @@ namespace UnityExtensionMethods
         }
 
         // Note: Memory Leak Potential
+        // Reads the image file directly from disk rather than through a file:// UnityWebRequest,
+        // which url-decodes '+' in the path to a space and fails for paths containing '+'
         public static IEnumerator CreateAndOutputSpriteFromImageFile(string imageFilePath, string backUpImageUrl)
         {
             if (!File.Exists(imageFilePath))
                 yield return SaveUrlToFile(backUpImageUrl, imageFilePath);
 
-            var imageUrl = FilePrefix + imageFilePath;
-
-            using var unityWebRequest = CreateUnityWebRequest(new Uri(imageUrl));
-            yield return unityWebRequest.SendWebRequest();
-            if (unityWebRequest.result != UnityWebRequest.Result.Success ||
-                !string.IsNullOrEmpty(unityWebRequest.error))
+            if (!File.Exists(imageFilePath))
             {
-                Debug.LogWarning("CreateAndOutputSpriteFromImageFile::unityWebRequest.Error:"
-                                 + unityWebRequest.error + " " + unityWebRequest.url);
+                Debug.LogWarning("CreateAndOutputSpriteFromImageFile::TextureFileMissing:" + imageFilePath);
                 yield return null;
+                yield break;
             }
-            else
-            {
-                var bytes = unityWebRequest.downloadHandler.data;
-                if (bytes is not { Length: > 0 })
-                {
-                    Debug.LogWarning("CreateAndOutputSpriteFromImageFile::TextureFileEmpty:" + unityWebRequest.url);
-                    yield return null;
-                }
 
-                var texture = imageUrl.EndsWith(WebpExtension) ? DecodeWebp(bytes) : CreateTexture2D(bytes);
-                yield return CreateSprite(texture);
+            byte[] bytes;
+#if UNITY_WEBGL
+            bytes = File.ReadAllBytes(imageFilePath);
+#else
+            var loadTask = Task.Run(() => File.ReadAllBytes(imageFilePath));
+            while (!loadTask.IsCompleted)
+                yield return null;
+            if (loadTask.IsFaulted)
+            {
+                Debug.LogWarning("CreateAndOutputSpriteFromImageFile::ReadFailed:" + loadTask.Exception);
+                yield return null;
+                yield break;
             }
+
+            bytes = loadTask.Result;
+#endif
+
+            if (bytes is not { Length: > 0 })
+            {
+                Debug.LogWarning("CreateAndOutputSpriteFromImageFile::TextureFileEmpty:" + imageFilePath);
+                File.Delete(imageFilePath);
+                yield return null;
+                yield break;
+            }
+
+            var texture = imageFilePath.EndsWith(WebpExtension) ? DecodeWebp(bytes) : CreateTexture2D(bytes);
+            if (texture == null)
+            {
+                // An undecodable cached file is likely a bad download (e.g. an error page),
+                // so delete it to allow re-downloading it on the next attempt
+                Debug.LogWarning("CreateAndOutputSpriteFromImageFile::UndecodableFileDeleted:" + imageFilePath);
+                File.Delete(imageFilePath);
+                yield return null;
+                yield break;
+            }
+
+            yield return CreateSprite(texture);
         }
 
         // Note: Memory Leak Potential

--- a/Assets/Scripts/UnityExtensionMethods/UnityFileMethods.cs
+++ b/Assets/Scripts/UnityExtensionMethods/UnityFileMethods.cs
@@ -351,7 +351,21 @@ namespace UnityExtensionMethods
 
             byte[] bytes;
 #if UNITY_WEBGL
-            bytes = File.ReadAllBytes(imageFilePath);
+            try
+            {
+                bytes = File.ReadAllBytes(imageFilePath);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning("CreateAndOutputSpriteFromImageFile::ReadFailed:" + ex);
+                bytes = null;
+            }
+
+            if (bytes == null)
+            {
+                yield return null;
+                yield break;
+            }
 #else
             var loadTask = Task.Run(() => File.ReadAllBytes(imageFilePath));
             while (!loadTask.IsCompleted)
@@ -369,7 +383,15 @@ namespace UnityExtensionMethods
             if (bytes is not { Length: > 0 })
             {
                 Debug.LogWarning("CreateAndOutputSpriteFromImageFile::TextureFileEmpty:" + imageFilePath);
-                File.Delete(imageFilePath);
+                try
+                {
+                    File.Delete(imageFilePath);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogWarning("CreateAndOutputSpriteFromImageFile::DeleteFailed:" + ex);
+                }
+
                 yield return null;
                 yield break;
             }

--- a/Assets/Scripts/UnityExtensionMethods/UnityFileMethods.cs
+++ b/Assets/Scripts/UnityExtensionMethods/UnityFileMethods.cs
@@ -380,7 +380,14 @@ namespace UnityExtensionMethods
                 // An undecodable cached file is likely a bad download (e.g. an error page),
                 // so delete it to allow re-downloading it on the next attempt
                 Debug.LogWarning("CreateAndOutputSpriteFromImageFile::UndecodableFileDeleted:" + imageFilePath);
-                File.Delete(imageFilePath);
+                try
+                {
+                    File.Delete(imageFilePath);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogWarning("CreateAndOutputSpriteFromImageFile::DeleteFailed:" + ex);
+                }
                 yield return null;
                 yield break;
             }


### PR DESCRIPTION
## What's Changed
- Fixed the Move To... menu so that all zones can be reached by scrolling, even in games with many zones
- Improved loading decks that list cards by card id
- Fixed card images sometimes failing to load, especially for image files with '+' in their name
- Fixed card images no longer loading after too many image errors
- Removed extra empty space at the end of scrolling menus

🤖 Generated with [Claude Code](https://claude.com/claude-code)