### PR TITLE
Add pagination, player rotation, and webp PDF fix

### DIFF
--- a/Assets/Scenes/CardsExplorer.unity
+++ b/Assets/Scenes/CardsExplorer.unity
@@ -734,6 +734,11 @@ PrefabInstance:
       propertyPath: tooltip
       value: Previous
       objectReference: {fileID: 0}
+    - target: {fileID: 60276916285824526, guid: 849115afddf0d7d48b0bd0f145f7349d,
+        type: 3}
+      propertyPath: inputActionId
+      value: Cards/PagePrevious
+      objectReference: {fileID: 0}
     - target: {fileID: 7317508625745834898, guid: 849115afddf0d7d48b0bd0f145f7349d,
         type: 3}
       propertyPath: m_LocalRotation.w
@@ -1436,6 +1441,11 @@ PrefabInstance:
         type: 3}
       propertyPath: tooltip
       value: Next
+      objectReference: {fileID: 0}
+    - target: {fileID: 60276916285824526, guid: 849115afddf0d7d48b0bd0f145f7349d,
+        type: 3}
+      propertyPath: inputActionId
+      value: Cards/PageNext
       objectReference: {fileID: 0}
     - target: {fileID: 7317508625745834898, guid: 849115afddf0d7d48b0bd0f145f7349d,
         type: 3}

--- a/Assets/Scripts/Cgs/AotTypeEnforcer.cs
+++ b/Assets/Scripts/Cgs/AotTypeEnforcer.cs
@@ -50,6 +50,7 @@ namespace Cgs
                 cardGame.CardImageFileType = string.Empty;
                 cardGame.CardImageProperty = string.Empty;
                 cardGame.CardImageUrl = string.Empty;
+                cardGame.CardImageUrlOverrides = new Dictionary<string, string>();
                 cardGame.CardNameBackIdentifier = string.Empty;
                 cardGame.CardNameIdentifier = string.Empty;
                 cardGame.CardNameIsUnique = false;
@@ -101,6 +102,7 @@ namespace Cgs
                 cardGame.GamePlayDeckName = string.Empty;
                 cardGame.GamePlayDeckPositions = new List<Float2>();
                 cardGame.GameDefaultCardAction = CardAction.Flip;
+                cardGame.GamePlayPlayerRotations = new List<float>();
                 var gamePlayZone = new GamePlayZone(FacePreference.Any, CardAction.Tap, string.Empty, float2, 0,
                     float2, GamePlayZoneType.Area);
                 var gamePlayZone2 = new GamePlayZone(FacePreference.Up, CardAction.Move, string.Empty, float2, 0,

--- a/Assets/Scripts/Cgs/Cards/CardSelector.cs
+++ b/Assets/Scripts/Cgs/Cards/CardSelector.cs
@@ -20,6 +20,14 @@ namespace Cgs.Cards
         private InputAction _moveAction;
         private InputAction _pageAction;
 
+        private bool IsBlocked => results.inputField.isFocused || CardGameManager.Instance.ModalCanvas != null;
+
+        private void OnEnable()
+        {
+            InputSystem.actions.FindAction(Tags.CardsPagePrevious).performed += InputPagePrevious;
+            InputSystem.actions.FindAction(Tags.CardsPageNext).performed += InputPageNext;
+        }
+
         private void Start()
         {
             CardViewer.Instance.buttonsPanel.gameObject.SetActive(true);
@@ -33,7 +41,7 @@ namespace Cgs.Cards
         // Poll for Vector2 inputs
         private void Update()
         {
-            if (CardGameManager.Instance.ModalCanvas != null || results.inputField.isFocused)
+            if (IsBlocked)
                 return;
 
             var pageVector2 = _pageAction?.ReadValue<Vector2>() ?? Vector2.zero;
@@ -92,7 +100,7 @@ namespace Cgs.Cards
 
         public void OnEndDrag(PointerEventData eventData)
         {
-            if (CardGameManager.Instance.ModalCanvas != null || results.inputField.isFocused)
+            if (IsBlocked)
                 return;
 
             var dragDelta = eventData.position - eventData.pressPosition;
@@ -118,7 +126,7 @@ namespace Cgs.Cards
         [UsedImplicitly]
         public void SelectDown()
         {
-            if (EventSystem.current.alreadySelecting)
+            if (IsBlocked || EventSystem.current.alreadySelecting)
                 return;
 
             if (results.layoutArea.childCount < 1)
@@ -152,7 +160,7 @@ namespace Cgs.Cards
         [UsedImplicitly]
         public void SelectUp()
         {
-            if (EventSystem.current.alreadySelecting)
+            if (IsBlocked || EventSystem.current.alreadySelecting)
                 return;
 
             if (results.layoutArea.childCount < 1)
@@ -186,7 +194,7 @@ namespace Cgs.Cards
         [UsedImplicitly]
         public void SelectLeft()
         {
-            if (EventSystem.current.alreadySelecting)
+            if (IsBlocked || EventSystem.current.alreadySelecting)
                 return;
 
             if (results.layoutArea.childCount < 1)
@@ -220,7 +228,7 @@ namespace Cgs.Cards
         [UsedImplicitly]
         public void SelectRight()
         {
-            if (EventSystem.current.alreadySelecting)
+            if (IsBlocked || EventSystem.current.alreadySelecting)
                 return;
 
             if (results.layoutArea.childCount < 1)
@@ -251,16 +259,38 @@ namespace Cgs.Cards
                 CardViewer.Instance.IsVisible = true;
         }
 
+        private void InputPagePrevious(InputAction.CallbackContext context)
+        {
+            if (IsBlocked || (CardViewer.Instance != null && CardViewer.Instance.Zoom))
+                return;
+
+            PageLeft();
+        }
+
         [UsedImplicitly]
         public void PageLeft()
         {
             results.DecrementPage();
         }
 
+        private void InputPageNext(InputAction.CallbackContext context)
+        {
+            if (IsBlocked || (CardViewer.Instance != null && CardViewer.Instance.Zoom))
+                return;
+
+            PageRight();
+        }
+
         [UsedImplicitly]
         public void PageRight()
         {
             results.IncrementPage();
+        }
+
+        private void OnDisable()
+        {
+            InputSystem.actions.FindAction(Tags.CardsPagePrevious).performed -= InputPagePrevious;
+            InputSystem.actions.FindAction(Tags.CardsPageNext).performed -= InputPageNext;
         }
     }
 }

--- a/Assets/Scripts/Cgs/Play/Multiplayer/CgsNetPlayer.cs
+++ b/Assets/Scripts/Cgs/Play/Multiplayer/CgsNetPlayer.cs
@@ -74,7 +74,7 @@ namespace Cgs.Play.Multiplayer
         {
             Send = new ClientRpcSendParams
             {
-                TargetClientIds = new[] {OwnerClientId}
+                TargetClientIds = new[] { OwnerClientId }
             }
         };
 
@@ -162,7 +162,7 @@ namespace Cgs.Play.Multiplayer
             }
         }
 
-        public int DefaultZRotation { get; private set; }
+        public float DefaultZRotation { get; private set; }
 
         public Quaternion DefaultRotation => Quaternion.Euler(new Vector3(0, 0, DefaultZRotation));
 
@@ -295,13 +295,10 @@ namespace Cgs.Play.Multiplayer
         // ReSharper disable once UnusedParameter.Local
         private void ApplyPlayerRotationOwnerClientRpc(int seatIndex, ClientRpcParams clientRpcParams = default)
         {
-            DefaultZRotation = (seatIndex % 4) switch
-            {
-                1 => 180,
-                2 => 90,
-                3 => 270,
-                _ => 0
-            };
+            DefaultZRotation = CardGameManager.Current.GamePlayPlayerRotations.Count > 0
+                ? CardGameManager.Current.GamePlayPlayerRotations[
+                    seatIndex % CardGameManager.Current.GamePlayPlayerRotations.Count]
+                : 0;
             Debug.Log("[CgsNet Player] Set PlayMat rotation based off seat index: " + DefaultZRotation);
             PlayController.Instance.playArea.CurrentRotation = DefaultZRotation;
 
@@ -680,7 +677,8 @@ namespace Cgs.Play.Multiplayer
 
         #region Cards
 
-        public void RequestNewCard(string cardId, Vector2 position, Quaternion rotation, bool isFacedown, bool isCardShared)
+        public void RequestNewCard(string cardId, Vector2 position, Quaternion rotation, bool isFacedown,
+            bool isCardShared)
         {
             SpawnCardInPlayAreaServerRpc(cardId, position, rotation, isFacedown, isCardShared);
         }

--- a/Assets/Scripts/Cgs/Tags.cs
+++ b/Assets/Scripts/Cgs/Tags.cs
@@ -38,6 +38,8 @@ namespace Cgs
         public const string CardsEdit = "Cards/Edit";
         public const string CardsSort = "Cards/Sort";
         public const string CardsFilter = "Cards/Filter";
+        public const string CardsPagePrevious = "Cards/PagePrevious";
+        public const string CardsPageNext = "Cards/PageNext";
 
         public const string DecksNew = "Decks/New";
         public const string DecksLoad = "Decks/Load";

--- a/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityDeck.cs
+++ b/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityDeck.cs
@@ -316,24 +316,37 @@ namespace FinolDigital.Cgs.Json.Unity
 
                 var imageFilePath = _cards[cardNumber].ImageFilePath;
                 XImage xImage;
-                if (imageFilePath.EndsWith(UnityFileMethods.WebpExtension, StringComparison.OrdinalIgnoreCase))
+                try
                 {
-                    // Texture2D.LoadImage() only supports png and jpg, so webp must be decoded and re-encoded
-                    if (!webpPngCache.TryGetValue(imageFilePath, out var pngBytes))
+                    if (imageFilePath.EndsWith(UnityFileMethods.WebpExtension, StringComparison.OrdinalIgnoreCase))
                     {
-                        var texture = UnityFileMethods.DecodeWebpReadable(File.ReadAllBytes(imageFilePath));
-                        if (texture == null)
-                            throw new InvalidOperationException("Unable to decode webp image: " + imageFilePath);
-                        pngBytes = texture.EncodeToPNG();
-                        UnityEngine.Object.Destroy(texture);
-                        webpPngCache[imageFilePath] = pngBytes;
+                        // Texture2D.LoadImage() only supports png and jpg, so webp must be decoded and re-encoded
+                        if (!webpPngCache.TryGetValue(imageFilePath, out var pngBytes))
+                        {
+                            var texture = UnityFileMethods.DecodeWebpReadable(File.ReadAllBytes(imageFilePath));
+                            if (texture == null)
+                            {
+                                const string DecodeErrorMessage = "Unable to decode webp image: ";
+                                throw new InvalidOperationException(DecodeErrorMessage + imageFilePath);
+                            }
+                            pngBytes = texture.EncodeToPNG();
+                            UnityEngine.Object.Destroy(texture);
+                            webpPngCache[imageFilePath] = pngBytes;
+                        }
+
+                        xImage = XImage.FromImageSource(ImageSource.FromBinary(imageFilePath, () => pngBytes, false));
                     }
-
-                    xImage = XImage.FromImageSource(ImageSource.FromBinary(imageFilePath, () => pngBytes, false));
+                    else
+                    {
+                        xImage = XImage.FromFile(imageFilePath);
+                    }
                 }
-                else
-                    xImage = XImage.FromFile(imageFilePath);
-
+                catch (Exception e)
+                {
+                    const string FileOpErrorMessage = "Failed to load image file for PDF rendering: ";
+                    Debug.LogError(FileOpErrorMessage + imageFilePath + " - " + e.Message);
+                    throw;
+                }
                 gfx.DrawImage(xImage, px, py, SourceGame.CardSize.X * PrintPdfPixelsPerInch,
                     SourceGame.CardSize.Y * PrintPdfPixelsPerInch);
                 px += SourceGame.CardSize.X * PrintPdfPixelsPerInch;

--- a/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityDeck.cs
+++ b/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityDeck.cs
@@ -13,6 +13,7 @@ using Didstopia.PDFSharp;
 using Didstopia.PDFSharp.Drawing;
 using Didstopia.PDFSharp.Pdf;
 using MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes;
+using UnityEngine;
 #endif
 
 namespace FinolDigital.Cgs.Json.Unity
@@ -302,6 +303,7 @@ namespace FinolDigital.Cgs.Json.Unity
             PdfPage page = null;
             XGraphics gfx = null;
             double px = PrintPdfMargin * PrintPdfPixelsPerInch, py = PrintPdfMargin * PrintPdfPixelsPerInch;
+            var webpPngCache = new Dictionary<string, byte[]>();
             for (var cardNumber = 0; cardNumber < Cards.Count; cardNumber++)
             {
                 if (page == null || cardNumber % cardsPerPage == 0)
@@ -312,7 +314,26 @@ namespace FinolDigital.Cgs.Json.Unity
                     py = PrintPdfMargin * PrintPdfPixelsPerInch;
                 }
 
-                var xImage = XImage.FromFile(_cards[cardNumber].ImageFilePath);
+                var imageFilePath = _cards[cardNumber].ImageFilePath;
+                XImage xImage;
+                if (imageFilePath.EndsWith(UnityFileMethods.WebpExtension, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Texture2D.LoadImage() only supports png and jpg, so webp must be decoded and re-encoded
+                    if (!webpPngCache.TryGetValue(imageFilePath, out var pngBytes))
+                    {
+                        var texture = UnityFileMethods.DecodeWebpReadable(File.ReadAllBytes(imageFilePath));
+                        if (texture == null)
+                            throw new InvalidOperationException("Unable to decode webp image: " + imageFilePath);
+                        pngBytes = texture.EncodeToPNG();
+                        UnityEngine.Object.Destroy(texture);
+                        webpPngCache[imageFilePath] = pngBytes;
+                    }
+
+                    xImage = XImage.FromImageSource(ImageSource.FromBinary(imageFilePath, () => pngBytes, false));
+                }
+                else
+                    xImage = XImage.FromFile(imageFilePath);
+
                 gfx.DrawImage(xImage, px, py, SourceGame.CardSize.X * PrintPdfPixelsPerInch,
                     SourceGame.CardSize.Y * PrintPdfPixelsPerInch);
                 px += SourceGame.CardSize.X * PrintPdfPixelsPerInch;

--- a/Assets/Scripts/UnityExtensionMethods/UnityFileMethods.cs
+++ b/Assets/Scripts/UnityExtensionMethods/UnityFileMethods.cs
@@ -28,7 +28,7 @@ namespace UnityExtensionMethods
         public const string MetaExtension = ".meta";
         public const string ZipExtension = ".zip";
         public const string JsonExtension = ".json";
-        private const string WebpExtension = ".webp";
+        public const string WebpExtension = ".webp";
         private const int MaxRetries = 3;
 
         public static string GetSafeFilePath(string filePath)
@@ -511,6 +511,35 @@ namespace UnityExtensionMethods
         {
             var textures = WebPDecoderWrapper.Decode(bytes).Result;
             return textures?.FirstOrDefault().Item1;
+        }
+
+        // Textures from DecodeWebp() are gpu-only, so this is for when the pixel data must be accessible from scripts
+        // Can return null
+        public static Texture2D DecodeWebpReadable(byte[] bytes)
+        {
+            var texture = WebP.Texture2DExt.CreateTexture2DFromWebP(bytes, lMipmaps: false, lLinear: false,
+                out var error, makeNoLongerReadable: false);
+            if (error == WebP.Error.Success && texture != null)
+                return texture;
+
+            // The static decoder cannot decode animated webp, so fall back to the animation decoder
+            // and copy its gpu-only texture into a readable one
+            var animatedTexture = DecodeWebp(bytes);
+            if (animatedTexture == null)
+                return null;
+
+            var renderTexture = RenderTexture.GetTemporary(animatedTexture.width, animatedTexture.height, 0);
+            Graphics.Blit(animatedTexture, renderTexture);
+            var previousActive = RenderTexture.active;
+            RenderTexture.active = renderTexture;
+            var readableTexture =
+                new Texture2D(animatedTexture.width, animatedTexture.height, TextureFormat.RGBA32, false);
+            readableTexture.ReadPixels(new Rect(0, 0, renderTexture.width, renderTexture.height), 0, 0);
+            readableTexture.Apply();
+            RenderTexture.active = previousActive;
+            RenderTexture.ReleaseTemporary(renderTexture);
+            UnityEngine.Object.Destroy(animatedTexture);
+            return readableTexture;
         }
 
         // Can return null

--- a/Assets/Scripts/UnityExtensionMethods/UnityFileMethods.cs
+++ b/Assets/Scripts/UnityExtensionMethods/UnityFileMethods.cs
@@ -517,10 +517,16 @@ namespace UnityExtensionMethods
         // Can return null
         public static Texture2D DecodeWebpReadable(byte[] bytes)
         {
+            if (bytes == null || bytes.Length == 0)
+                return null;
+
             var texture = WebP.Texture2DExt.CreateTexture2DFromWebP(bytes, lMipmaps: false, lLinear: false,
                 out var error, makeNoLongerReadable: false);
             if (error == WebP.Error.Success && texture != null)
                 return texture;
+
+            if (texture != null)
+                UnityEngine.Object.Destroy(texture);
 
             // The static decoder cannot decode animated webp, so fall back to the animation decoder
             // and copy its gpu-only texture into a readable one
@@ -529,17 +535,23 @@ namespace UnityExtensionMethods
                 return null;
 
             var renderTexture = RenderTexture.GetTemporary(animatedTexture.width, animatedTexture.height, 0);
-            Graphics.Blit(animatedTexture, renderTexture);
             var previousActive = RenderTexture.active;
-            RenderTexture.active = renderTexture;
-            var readableTexture =
-                new Texture2D(animatedTexture.width, animatedTexture.height, TextureFormat.RGBA32, false);
-            readableTexture.ReadPixels(new Rect(0, 0, renderTexture.width, renderTexture.height), 0, 0);
-            readableTexture.Apply();
-            RenderTexture.active = previousActive;
-            RenderTexture.ReleaseTemporary(renderTexture);
-            UnityEngine.Object.Destroy(animatedTexture);
-            return readableTexture;
+            try
+            {
+                Graphics.Blit(animatedTexture, renderTexture);
+                RenderTexture.active = renderTexture;
+                var readableTexture =
+                    new Texture2D(animatedTexture.width, animatedTexture.height, TextureFormat.RGBA32, false);
+                readableTexture.ReadPixels(new Rect(0, 0, renderTexture.width, renderTexture.height), 0, 0);
+                readableTexture.Apply();
+                return readableTexture;
+            }
+            finally
+            {
+                RenderTexture.active = previousActive;
+                RenderTexture.ReleaseTemporary(renderTexture);
+                UnityEngine.Object.Destroy(animatedTexture);
+            }
         }
 
         // Can return null

--- a/docs/games/grand_archive_pantheon/cgs.json
+++ b/docs/games/grand_archive_pantheon/cgs.json
@@ -301,6 +301,7 @@
 			"y": 0
 		}
 	],
+	"gamePlayPlayerRotations": [0, 180, 0, 180],
 	"gamePlayZones": [
 		{
 			"defaultCardAction": "flip",

--- a/docs/schema/cgs.json
+++ b/docs/schema/cgs.json
@@ -183,6 +183,13 @@
       "description": "cardImageUrl is a parameterized template url from which CGS downloads card image files if <cardImageProperty> is empty. Parameters: {cardId}=*Card:Id*, {cardName}=*Card:Name*, {cardSet}=*Card:SetCode*, {cardImageFileType}=<cardImageFileType>, {<property>}=*Card:<property>*. Example: https://www.cardgamesimulator.com/games/Standard/sets/{cardSet}/{cardId}.{cardImageFileType}",
       "format": "uri-template"
     },
+    "cardImageUrlOverrides": {
+      "type": "object",
+      "description": "cardImageUrlOverrides is a map where the key is the *Card:Id* and the value is the parameterized template url for that Card, overriding <cardImageUrl>.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
     "cardNameBackIdentifier": {
       "type": "string",
       "description": "When defining a Card in AllCards.json or AllSets.json, you can have the *Card:Name* of the back face mapped to the field defined by cardNameBackIdentifier. Most custom games will likely want to keep the default cardNameBackIdentifier."
@@ -368,6 +375,20 @@
       "description": "Each deck loaded during a game will be loaded to its corresponding position in gamePlayDeckPositions. The first deck loaded will go to the first position, second to second, etc.",
       "items": {
         "$ref": "#/definitions/Float2"
+      }
+    },
+    "gamePlayPlayerRotations": {
+      "type": "array",
+      "description": "Players will be oriented around the play area by rotating (in degrees) according to the values in gamePlayPlayerRotations. The first value corresponds to the first player, the second to the second player, etc.",
+      "default": [
+        0.0,
+        180.0,
+        90.0,
+        270.0
+      ],
+      "items": {
+        "type": "number",
+        "format": "float"
       }
     },
     "gamePlayZones": {


### PR DESCRIPTION
## What's Changed
- Fixed Print to PDF for decks that use webp card images
- Game creators can now use gamePlayPlayersRotation to set how players rotate around the table
- Added shortcuts to go to the previous/next page when browsing cards