### PR TITLE
Card navigation while zoomed in the Deck Editor

### DIFF
--- a/Assets/Prefabs/CardGameView/Viewer/Card Viewer.prefab
+++ b/Assets/Prefabs/CardGameView/Viewer/Card Viewer.prefab
@@ -4672,6 +4672,11 @@ PrefabInstance:
       propertyPath: tooltip
       value: Next
       objectReference: {fileID: 0}
+    - target: {fileID: 5634861638736528653, guid: 7dc4df6ef81af5745aaf0b3e9d186737,
+        type: 3}
+      propertyPath: inputActionId
+      value: Cards/PageNext
+      objectReference: {fileID: 0}
     - target: {fileID: 7136752755737282221, guid: 7dc4df6ef81af5745aaf0b3e9d186737,
         type: 3}
       propertyPath: m_Sprite
@@ -6488,6 +6493,11 @@ PrefabInstance:
         type: 3}
       propertyPath: tooltip
       value: Previous
+      objectReference: {fileID: 0}
+    - target: {fileID: 5634861638736528653, guid: 7dc4df6ef81af5745aaf0b3e9d186737,
+        type: 3}
+      propertyPath: inputActionId
+      value: Cards/PagePrevious
       objectReference: {fileID: 0}
     - target: {fileID: 7136752755737282221, guid: 7dc4df6ef81af5745aaf0b3e9d186737,
         type: 3}

--- a/Assets/Scenes/DeckEditor.unity
+++ b/Assets/Scenes/DeckEditor.unity
@@ -2827,6 +2827,11 @@ PrefabInstance:
       propertyPath: tooltip
       value: Previous
       objectReference: {fileID: 0}
+    - target: {fileID: 60276916285824526, guid: 849115afddf0d7d48b0bd0f145f7349d,
+        type: 3}
+      propertyPath: inputActionId
+      value: Cards/PagePrevious
+      objectReference: {fileID: 0}
     - target: {fileID: 7317508625745834898, guid: 849115afddf0d7d48b0bd0f145f7349d,
         type: 3}
       propertyPath: m_LocalRotation.w
@@ -3227,6 +3232,11 @@ PrefabInstance:
         type: 3}
       propertyPath: tooltip
       value: Next
+      objectReference: {fileID: 0}
+    - target: {fileID: 60276916285824526, guid: 849115afddf0d7d48b0bd0f145f7349d,
+        type: 3}
+      propertyPath: inputActionId
+      value: Cards/PageNext
       objectReference: {fileID: 0}
     - target: {fileID: 7317508625745834898, guid: 849115afddf0d7d48b0bd0f145f7349d,
         type: 3}
@@ -6145,6 +6155,11 @@ PrefabInstance:
         type: 3}
       propertyPath: tooltip
       value: Next
+      objectReference: {fileID: 0}
+    - target: {fileID: 5634861638736528653, guid: 7dc4df6ef81af5745aaf0b3e9d186737,
+        type: 3}
+      propertyPath: inputActionId
+      value: Cards/PageNext
       objectReference: {fileID: 0}
     - target: {fileID: 7136752755737282221, guid: 7dc4df6ef81af5745aaf0b3e9d186737,
         type: 3}
@@ -9156,6 +9171,11 @@ PrefabInstance:
         type: 3}
       propertyPath: tooltip
       value: Previous
+      objectReference: {fileID: 0}
+    - target: {fileID: 5634861638736528653, guid: 7dc4df6ef81af5745aaf0b3e9d186737,
+        type: 3}
+      propertyPath: inputActionId
+      value: Cards/PagePrevious
       objectReference: {fileID: 0}
     - target: {fileID: 7136752755737282221, guid: 7dc4df6ef81af5745aaf0b3e9d186737,
         type: 3}

--- a/Assets/Scripts/Cgs/Cards/CardSelector.cs
+++ b/Assets/Scripts/Cgs/Cards/CardSelector.cs
@@ -261,10 +261,13 @@ namespace Cgs.Cards
 
         private void InputPagePrevious(InputAction.CallbackContext context)
         {
-            if (IsBlocked || (CardViewer.Instance != null && CardViewer.Instance.Zoom))
+            if (IsBlocked)
                 return;
 
-            PageLeft();
+            if (CardViewer.Instance != null && CardViewer.Instance.Zoom)
+                SelectLeft();
+            else
+                PageLeft();
         }
 
         [UsedImplicitly]
@@ -275,10 +278,13 @@ namespace Cgs.Cards
 
         private void InputPageNext(InputAction.CallbackContext context)
         {
-            if (IsBlocked || (CardViewer.Instance != null && CardViewer.Instance.Zoom))
+            if (IsBlocked)
                 return;
 
-            PageRight();
+            if (CardViewer.Instance != null && CardViewer.Instance.Zoom)
+                SelectRight();
+            else
+                PageRight();
         }
 
         [UsedImplicitly]

--- a/Assets/Scripts/Cgs/Decks/DeckCardSelector.cs
+++ b/Assets/Scripts/Cgs/Decks/DeckCardSelector.cs
@@ -23,6 +23,10 @@ namespace Cgs.Decks
         private bool IsBlocked =>
             CardGameManager.Instance.ModalCanvas != null || editor.searchResults.inputField.isFocused;
 
+        private bool IsSelectedCardInDeck =>
+            CardViewer.Instance != null && CardViewer.Instance.SelectedCardModel != null &&
+            editor.CardModels.Contains(CardViewer.Instance.SelectedCardModel);
+
         private void OnEnable()
         {
             InputSystem.actions.FindAction(Tags.CardsPagePrevious).performed += InputPagePrevious;
@@ -32,8 +36,8 @@ namespace Cgs.Decks
         private void Start()
         {
             CardViewer.Instance.buttonsPanel.gameObject.SetActive(true);
-            CardViewer.Instance.previousButton.onClick.AddListener(SelectResultsUp);
-            CardViewer.Instance.nextButton.onClick.AddListener(SelectResultsDown);
+            CardViewer.Instance.previousButton.onClick.AddListener(SelectPrevious);
+            CardViewer.Instance.nextButton.onClick.AddListener(SelectNext);
 
             _moveAction = InputSystem.actions.FindAction(Tags.PlayerMove);
             _pageAction = InputSystem.actions.FindAction(Tags.PlayerPage);
@@ -236,9 +240,17 @@ namespace Cgs.Decks
                 return;
 
             if (CardViewer.Instance != null && CardViewer.Instance.Zoom)
-                SelectResultsUp();
+                SelectPrevious();
             else
                 NavigateLeft();
+        }
+
+        private void SelectPrevious()
+        {
+            if (IsSelectedCardInDeck)
+                SelectEditorLeft();
+            else
+                SelectResultsUp();
         }
 
         [UsedImplicitly]
@@ -253,9 +265,17 @@ namespace Cgs.Decks
                 return;
 
             if (CardViewer.Instance != null && CardViewer.Instance.Zoom)
-                SelectResultsDown();
+                SelectNext();
             else
                 NavigateRight();
+        }
+
+        private void SelectNext()
+        {
+            if (IsSelectedCardInDeck)
+                SelectEditorRight();
+            else
+                SelectResultsDown();
         }
 
         [UsedImplicitly]
@@ -289,14 +309,14 @@ namespace Cgs.Decks
             {
                 if (results.layoutArea.GetChild(i).GetComponent<CardModel>() != CardViewer.Instance.SelectedCardModel)
                     continue;
-                i++;
-                if (i == results.layoutArea.childCount)
+                var next = i + 1;
+                if (next == results.layoutArea.childCount)
                 {
                     results.IncrementPage();
-                    i = 0;
+                    next = 0;
                 }
 
-                EventSystem.current.SetSelectedGameObject(results.layoutArea.GetChild(i).gameObject);
+                EventSystem.current.SetSelectedGameObject(results.layoutArea.GetChild(next).gameObject);
                 return;
             }
 
@@ -320,14 +340,14 @@ namespace Cgs.Decks
             {
                 if (results.layoutArea.GetChild(i).GetComponent<CardModel>() != CardViewer.Instance.SelectedCardModel)
                     continue;
-                i--;
-                if (i < 0)
+                var previous = i - 1;
+                if (previous < 0)
                 {
                     results.DecrementPage();
-                    i = results.layoutArea.childCount - 1;
+                    previous = results.layoutArea.childCount - 1;
                 }
 
-                EventSystem.current.SetSelectedGameObject(results.layoutArea.GetChild(i).gameObject);
+                EventSystem.current.SetSelectedGameObject(results.layoutArea.GetChild(previous).gameObject);
                 return;
             }
 

--- a/Assets/Scripts/Cgs/Decks/DeckCardSelector.cs
+++ b/Assets/Scripts/Cgs/Decks/DeckCardSelector.cs
@@ -20,8 +20,21 @@ namespace Cgs.Decks
         private InputAction _moveAction;
         private InputAction _pageAction;
 
+        private bool IsBlocked =>
+            CardGameManager.Instance.ModalCanvas != null || editor.searchResults.inputField.isFocused;
+
+        private void OnEnable()
+        {
+            InputSystem.actions.FindAction(Tags.CardsPagePrevious).performed += InputPagePrevious;
+            InputSystem.actions.FindAction(Tags.CardsPageNext).performed += InputPageNext;
+        }
+
         private void Start()
         {
+            CardViewer.Instance.buttonsPanel.gameObject.SetActive(true);
+            CardViewer.Instance.previousButton.onClick.AddListener(SelectResultsUp);
+            CardViewer.Instance.nextButton.onClick.AddListener(SelectResultsDown);
+
             _moveAction = InputSystem.actions.FindAction(Tags.PlayerMove);
             _pageAction = InputSystem.actions.FindAction(Tags.PlayerPage);
         }
@@ -29,7 +42,7 @@ namespace Cgs.Decks
         // Poll for Vector2 inputs
         private void Update()
         {
-            if (CardGameManager.Instance.ModalCanvas != null || editor.searchResults.inputField.isFocused)
+            if (IsBlocked)
                 return;
 
             if (_moveAction?.WasPressedThisFrame() ?? false)
@@ -71,9 +84,7 @@ namespace Cgs.Decks
 
         public void OnEndDrag(PointerEventData eventData)
         {
-            if (CardGameManager.Instance.ModalCanvas != null || editor.searchResults.inputField.isFocused
-                                                             || !CardViewer.Instance.Zoom ||
-                                                             CardViewer.Instance.ZoomTime <= 0.5f)
+            if (IsBlocked || !CardViewer.Instance.Zoom || CardViewer.Instance.ZoomTime <= 0.5f)
                 return;
 
             var dragDelta = eventData.position - eventData.pressPosition;
@@ -101,7 +112,7 @@ namespace Cgs.Decks
 
         private void SelectEditorLeft()
         {
-            if (EventSystem.current.alreadySelecting)
+            if (IsBlocked || EventSystem.current.alreadySelecting)
                 return;
 
             var editorCardModels = editor.CardModels;
@@ -131,7 +142,7 @@ namespace Cgs.Decks
 
         private void SelectEditorRight()
         {
-            if (EventSystem.current.alreadySelecting)
+            if (IsBlocked || EventSystem.current.alreadySelecting)
                 return;
 
             var editorCardModels = editor.CardModels;
@@ -161,7 +172,7 @@ namespace Cgs.Decks
 
         private void SelectEditorDown()
         {
-            if (EventSystem.current.alreadySelecting)
+            if (IsBlocked || EventSystem.current.alreadySelecting)
                 return;
 
             var editorCardModels = editor.CardModels;
@@ -191,7 +202,7 @@ namespace Cgs.Decks
 
         private void SelectEditorUp()
         {
-            if (EventSystem.current.alreadySelecting)
+            if (IsBlocked || EventSystem.current.alreadySelecting)
                 return;
 
             var editorCardModels = editor.CardModels;
@@ -219,10 +230,32 @@ namespace Cgs.Decks
                 CardViewer.Instance.IsVisible = true;
         }
 
+        private void InputPagePrevious(InputAction.CallbackContext context)
+        {
+            if (IsBlocked)
+                return;
+
+            if (CardViewer.Instance != null && CardViewer.Instance.Zoom)
+                SelectResultsUp();
+            else
+                NavigateLeft();
+        }
+
         [UsedImplicitly]
         public void NavigateLeft()
         {
             results.DecrementPage();
+        }
+
+        private void InputPageNext(InputAction.CallbackContext context)
+        {
+            if (IsBlocked)
+                return;
+
+            if (CardViewer.Instance != null && CardViewer.Instance.Zoom)
+                SelectResultsDown();
+            else
+                NavigateRight();
         }
 
         [UsedImplicitly]
@@ -243,7 +276,7 @@ namespace Cgs.Decks
 
         private void SelectResultsDown()
         {
-            if (EventSystem.current.alreadySelecting)
+            if (IsBlocked || EventSystem.current.alreadySelecting)
                 return;
 
             if (results.layoutArea.childCount < 1)
@@ -274,7 +307,7 @@ namespace Cgs.Decks
 
         private void SelectResultsUp()
         {
-            if (EventSystem.current.alreadySelecting)
+            if (IsBlocked || EventSystem.current.alreadySelecting)
                 return;
 
             if (results.layoutArea.childCount < 1)
@@ -301,6 +334,12 @@ namespace Cgs.Decks
             EventSystem.current.SetSelectedGameObject(results.layoutArea.GetChild(0).gameObject);
             if (CardViewer.Instance != null && CardViewer.Instance.SelectedCardModel != null)
                 CardViewer.Instance.IsVisible = true;
+        }
+
+        private void OnDisable()
+        {
+            InputSystem.actions.FindAction(Tags.CardsPagePrevious).performed -= InputPagePrevious;
+            InputSystem.actions.FindAction(Tags.CardsPageNext).performed -= InputPageNext;
         }
     }
 }


### PR DESCRIPTION
## What's Changed
- While zoomed in on a card in the Deck Editor, you can now use the next/previous buttons or page keys to flip through the other cards
- Zooming on a card from your deck flips through the deck, and zooming on a search result flips through the search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)