### PR TITLE
Auto-move cards into card zones

### DIFF
--- a/Assets/InputSystem_Actions.inputactions
+++ b/Assets/InputSystem_Actions.inputactions
@@ -1016,6 +1016,24 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "PagePrevious",
+                    "type": "Button",
+                    "id": "fb72ad10-be5f-4937-906c-9157d135be4f",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "PageNext",
+                    "type": "Button",
+                    "id": "718629b2-7db2-4da9-98a9-dad7fc5da1da",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -1148,6 +1166,50 @@
                     "processors": "",
                     "groups": ";Keyboard&Mouse",
                     "action": "Sort",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4d2384ed-0589-4f63-8323-7506452b2db5",
+                    "path": "<Gamepad>/leftTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "PagePrevious",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "ef1d7428-c788-44dc-87ff-94a5d03441eb",
+                    "path": "<Keyboard>/comma",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "PagePrevious",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "345c7f6b-800d-48d2-a13d-34744fd3b093",
+                    "path": "<Gamepad>/rightTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "PageNext",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "6208998e-998e-4e40-8517-53512224c104",
+                    "path": "<Keyboard>/period",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "PageNext",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Prefabs/CardGameView/Multiplayer/Card Stack.prefab
+++ b/Assets/Prefabs/CardGameView/Multiplayer/Card Stack.prefab
@@ -149,12 +149,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 3701492064
+  GlobalObjectIdHash: 3001253089
   InScenePlacedSourceGlobalObjectIdHash: 0
   DeferredDespawnTick: 0
   Ownership: 1
   AlwaysReplicateAsRoot: 0
   SynchronizeTransform: 1
+  <InScenePlaced>k__BackingField: 0
   ActiveSceneSynchronization: 0
   SceneMigrationSynchronization: 1
   SpawnWithObservers: 1

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardModel.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardModel.cs
@@ -232,6 +232,9 @@ namespace Cgs.CardGameView.Multiplayer
 
                 var stackDropArea = gameObject.GetOrAddComponent<StackDropArea>();
                 stackDropArea.DropHandler = this;
+
+                // Cards spawned over the network skip OnAdd, so the owner checks for card zone capture here
+                MoveToOverlappingCardZone();
             }
 
             var cardSize = new Vector2(CardGameManager.Current.CardSize.X, CardGameManager.Current.CardSize.Y);
@@ -696,6 +699,29 @@ namespace Cgs.CardGameView.Multiplayer
             var cardZone = ParentCardZone;
             if (cardZone != null)
                 cardZone.UpdateScrollRect(CurrentDragPhase, CurrentPointerEventData);
+        }
+
+        public bool MoveToOverlappingCardZone()
+        {
+            if (IsStatic || ToDelete || IsMovingToPlaceHolder || PlaceHolderCardZone != null)
+                return false;
+
+            if (PlayController.Instance == null ||
+                PlayController.Instance.playAreaCardZone.transform != transform.parent)
+                return false;
+
+            // For spawned cards, only the owner moves the card, and the move syncs through MoveCardToServer
+            if (IsSpawned && !IsOwner)
+                return false;
+
+            var cardZone = PlayController.Instance.FindCardZoneAt(transform.position);
+            if (cardZone == null)
+                return false;
+
+            PlaceHolderCardZone = cardZone;
+            cardZone.UpdateLayout(PlaceHolder, transform.position);
+            IsMovingToPlaceHolder = true;
+            return true;
         }
 
         private void UpdateCheckForPlaceHolder()

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardZone.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardZone.cs
@@ -289,6 +289,10 @@ namespace Cgs.CardGameView.Multiplayer
             if (cardModel == null)
                 return;
 
+            // A card added over a nested card zone belongs in that zone, not loose in this area
+            if (Type == CardZoneType.Area && cardModel.MoveToOverlappingCardZone())
+                return;
+
             if (Type == CardZoneType.Area)
                 cardModel.SnapToGrid();
 

--- a/Assets/Scripts/Cgs/Play/PlayController.cs
+++ b/Assets/Scripts/Cgs/Play/PlayController.cs
@@ -744,10 +744,14 @@ namespace Cgs.Play
             if (cardModel.IsFacedown && cardModel.Value.IsBackFaceCard)
                 cardModel.IsFacedown = false;
 
+        private static void AddCardToPlayArea(CardZone cardZone, CardModel cardModel)
+        {
+           if (cardModel == null)
+               return;
+
             // A card added over a card zone moves into that zone, which then applies its own add actions
             if (cardModel.MoveToOverlappingCardZone())
                 return;
-
             if (CgsNetManager.Instance.IsOnline && !cardModel.IsSpawned)
                 CgsNetManager.Instance.LocalPlayer.MoveCardToServer(cardZone, cardModel);
             else

--- a/Assets/Scripts/Cgs/Play/PlayController.cs
+++ b/Assets/Scripts/Cgs/Play/PlayController.cs
@@ -741,13 +741,11 @@ namespace Cgs.Play
 
         private static void AddCardToPlayArea(CardZone cardZone, CardModel cardModel)
         {
+            if (cardModel == null)
+                return;
+
             if (cardModel.IsFacedown && cardModel.Value.IsBackFaceCard)
                 cardModel.IsFacedown = false;
-
-        private static void AddCardToPlayArea(CardZone cardZone, CardModel cardModel)
-        {
-           if (cardModel == null)
-               return;
 
             // A card added over a card zone moves into that zone, which then applies its own add actions
             if (cardModel.MoveToOverlappingCardZone())
@@ -904,7 +902,7 @@ namespace Cgs.Play
             var zone = new GamePlayZoneParams
             {
                 Type = gamePlayZone.Type.ToString(),
-                Name = gamePlayZone.Name ?? string.Empty,
+                Name = gamePlayZone.Name,
                 Position = CardGameManager.PixelsPerInch *
                            new Vector2(gamePlayZone.Position.X, gamePlayZone.Position.Y),
                 Rotation = Quaternion.Euler(0, 0, gamePlayZone.Rotation),

--- a/Assets/Scripts/Cgs/Play/PlayController.cs
+++ b/Assets/Scripts/Cgs/Play/PlayController.cs
@@ -192,6 +192,22 @@ namespace Cgs.Play
 
         public IEnumerable<CardZone> AllCardZones => playAreaCardZone.GetComponentsInChildren<CardZone>();
 
+        public CardZone FindCardZoneAt(Vector2 worldPosition)
+        {
+            foreach (var cardZone in AllCardZones)
+            {
+                if (cardZone == playAreaCardZone ||
+                    cardZone.Type is not (CardZoneType.Horizontal or CardZoneType.Vertical))
+                    continue;
+
+                var rectTransform = (RectTransform)cardZone.transform;
+                if (rectTransform.rect.Contains((Vector2)rectTransform.InverseTransformPoint(worldPosition)))
+                    return cardZone;
+            }
+
+            return null;
+        }
+
         public CardStack CurrentDeckStack { get; set; }
 
         // Solo play: which seat block the next deck load occupies (counts deck loads, not stacks)
@@ -727,6 +743,10 @@ namespace Cgs.Play
         {
             if (cardModel.IsFacedown && cardModel.Value.IsBackFaceCard)
                 cardModel.IsFacedown = false;
+
+            // A card added over a card zone moves into that zone, which then applies its own add actions
+            if (cardModel.MoveToOverlappingCardZone())
+                return;
 
             if (CgsNetManager.Instance.IsOnline && !cardModel.IsSpawned)
                 CgsNetManager.Instance.LocalPlayer.MoveCardToServer(cardZone, cardModel);

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.davidmfinol.sfb": "https://github.com/davidmfinol/UnityStandaloneFileBrowser.git",
-    "com.kyrylokuzyk.primetween": "1.4.8",
+    "com.kyrylokuzyk.primetween": "1.4.11",
     "com.netpyoung.webp": "0.3.22",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.ide.rider": "3.0.40",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -8,7 +8,7 @@
       "hash": "65aa6b13a629ff91b45e20bfb1543f8839aad75b"
     },
     "com.kyrylokuzyk.primetween": {
-      "version": "1.4.8",
+      "version": "1.4.11",
       "depth": 0,
       "source": "registry",
       "dependencies": {},

--- a/openspec/changes/archive/2026-07-19-auto-move-cards-into-zones/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-19-auto-move-cards-into-zones/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/archive/2026-07-19-auto-move-cards-into-zones/design.md
+++ b/openspec/changes/archive/2026-07-19-auto-move-cards-into-zones/design.md
@@ -1,0 +1,39 @@
+# Design: Auto-Move Cards Into Overlapping Card Zones
+
+## Context
+
+The play area is itself a `CardZone` of type `Area` (`PlayController.playAreaCardZone`), and games can define child card zones (`CardZoneType.Horizontal` / `Vertical`) inside it. Today, zone capture only happens during drag: `CardZone.OnPointerEnterPlayable` sets `CardModel.PlaceHolderCardZone`, which creates a placeholder `RectTransform` inside the zone; on release, `IsMovingToPlaceHolder` animates the card to the placeholder and `FinishMovingToPlaceHolder` reparents the card into the zone, firing the zone's `OnAddCardActions` (face preference, default action, `MoveCardToServer`).
+
+Programmatic adds bypass all of this. `PlayController.AddCardToPlayArea`, deck-play (`MoveToPlay`), card search (`AddCard`), and network spawns parent the card directly under `playAreaCardZone`; `CardZone.OnAdd` for an Area zone just calls `SnapToGrid()`. A card can therefore visually sit on a zone without belonging to it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Any card that becomes a direct child of the play area card zone and whose position overlaps a child card zone is moved into that zone via the existing placeholder flow.
+- Zone add behaviors (face preference, default card action, multiplayer sync) apply exactly as they do for drag-and-drop capture.
+- Works in solo and multiplayer, regardless of which code path added the card.
+
+**Non-Goals:**
+- Changing drag-and-drop capture behavior.
+- Capturing cards into `CardStack`s or `Area`-type child zones (only Horizontal/Vertical zones, matching the drag-capture check in `CardModel.UpdatePosition`).
+- Retroactively capturing cards that already overlap a zone when the zone is created or moved.
+- Changing the multiplayer protocol.
+
+## Decisions
+
+1. **Hook points: capture logic lives in `CardModel.MoveToOverlappingCardZone()`, invoked from three thin call sites.** Implementation revealed that `CardZone.OnAdd` alone does not cover all paths: solo deck-play (`MoveToPlay`) and `PlayController.AddCard` call `AddCardToPlayArea` directly without `OnAdd`, and cards spawned over the network reach clients only via `OnNetworkSpawn`/`OnStartPlayable`. The guarded capture method is therefore called from: (a) `CardZone.OnAdd` for Area zones, before `SnapToGrid()`; (b) `PlayController.AddCardToPlayArea`, before the online/solo branch; (c) `CardModel.OnStartPlayable` when the card starts as a direct child of the play area (covers network-spawned cards; only the owner acts). The method is idempotent and guard-protected, so overlapping call sites are harmless.
+
+2. **Overlap test: card world position transformed into the zone's local rect.** Programmatic adds have no `PointerEventData`, so `RectTransformUtility.RectangleContainsScreenPoint` with pointer position (used during drag) is unavailable. Instead, `PlayController.FindCardZoneAt(worldPosition)` transforms the card's world position into each candidate zone's local space (`InverseTransformPoint`) and tests `rect.Contains`, which stays correct under zone rotation and scale. First overlapping Horizontal/Vertical zone wins, iterating `PlayController.AllCardZones` and skipping the play area zone itself.
+
+3. **Reuse the placeholder flow rather than reparenting directly.** Setting `cardModel.PlaceHolderCardZone = zone` creates the placeholder in the zone; `zone.UpdateLayout(placeholder, cardPosition)` picks the correct sibling index for Horizontal/Vertical layout; then the card is flagged to move to the placeholder so `Update` animates it and `FinishMovingToPlaceHolder` reparents it, firing `OnAddCardActions`. This matches the requested UX (visible movement into the zone) and guarantees identical side effects to drag capture. `IsMovingToPlaceHolder` remains private: the entire capture (guards, zone lookup, placeholder creation, animation start) is encapsulated in the public `CardModel.MoveToOverlappingCardZone()`, so callers never touch the flag directly.
+
+4. **Skip capture when it does not apply.** No capture when the card `IsStatic`, is marked `ToDelete`, already has a `PlaceHolderCardZone` (drag flow in progress), or overlaps no child zone. In those cases behavior is unchanged (`SnapToGrid` for the play area).
+
+5. **Multiplayer sync comes for free.** `FinishMovingToPlaceHolder` reparents the card into the zone, and the zone's `OnAddCardActions` include `CgsNetManager.Instance.LocalPlayer.MoveCardToServer`, which already syncs container changes. Only the client that created the card runs the capture; other clients receive the resulting container update.
+
+## Risks / Trade-offs
+
+- [Capture races with AutoStack/SnapToGrid deletion] → Run the zone-overlap check before `SnapToGrid()` in `OnAdd` and return early on capture, so the card cannot be stacked/deleted and captured simultaneously.
+- [Card spawned at a position overlapping multiple zones] → First matching zone in `AllCardZones` order wins; deterministic and matches drag behavior (last-writer during drag is effectively arbitrary too).
+- [Network timing: card or zone not yet spawned when `OnAdd` runs on a client] → Capture runs only on the originating client (the one that calls `OnAdd`); zones are found via `PlayController.AllCardZones`, which only returns instantiated zones. If the zone is absent locally, the card simply stays in the play area (current behavior).
+- [Placeholder lost mid-animation (zone deleted)] → Existing `FinishMovingToPlaceHolder`/`RecoverLostPlaceholder` warning paths already handle a null placeholder; no new handling needed.

--- a/openspec/changes/archive/2026-07-19-auto-move-cards-into-zones/proposal.md
+++ b/openspec/changes/archive/2026-07-19-auto-move-cards-into-zones/proposal.md
@@ -1,0 +1,29 @@
+# Auto-Move Cards Into Overlapping Card Zones
+
+## Why
+
+While playing a game, a card can end up sitting on top of a card zone in the play area without actually being in that zone. Card zones only capture cards during a drag (via pointer-enter placeholders), so cards added to the play area programmatically — played from a deck, added from card search, or spawned over the network — land at a position that may overlap a zone but are never moved into it. This breaks the expectation that a zone contains whatever cards visibly rest on it.
+
+## What Changes
+
+- When a card is added to the play area card zone and its position overlaps a child card zone (horizontal or vertical zone), the card is automatically moved into that zone instead of remaining loose in the play area.
+- The move uses the existing placeholder mechanism: a placeholder is created in the overlapping zone at the appropriate layout position, and the card animates to the placeholder, then reparents into the zone (same flow as drag-and-drop capture).
+- Cards that do not overlap any child card zone keep the current behavior (snap to grid in the play area).
+- Applies in both solo and multiplayer play, for all code paths that add cards to the play area.
+
+## Capabilities
+
+### New Capabilities
+
+- `card-zone-capture`: Automatic capture of cards into card zones when a card added to the play area overlaps a zone, including placeholder creation, movement animation, and zone add behaviors (face preference, default action).
+
+### Modified Capabilities
+
+<!-- None: existing specs (card-back-persistence, card-flip-animation, card-rotation-animation, netplayable-ownership, schema-validation-test-mode, seat-based-deck-placement) have no requirement changes. -->
+
+## Impact
+
+- `Assets/Scripts/Cgs/CardGameView/Multiplayer/CardZone.cs` — `OnAdd` for the play area zone gains an overlap check against child card zones.
+- `Assets/Scripts/Cgs/CardGameView/Multiplayer/CardModel.cs` — placeholder / move-to-placeholder flow reused for programmatic adds.
+- `Assets/Scripts/Cgs/Play/PlayController.cs` — `AddCardToPlayArea` and related card-creation paths.
+- Multiplayer: zone membership already syncs via existing `MoveCardToServer` on zone add; no protocol changes expected.

--- a/openspec/changes/archive/2026-07-19-auto-move-cards-into-zones/specs/card-zone-capture/spec.md
+++ b/openspec/changes/archive/2026-07-19-auto-move-cards-into-zones/specs/card-zone-capture/spec.md
@@ -1,0 +1,47 @@
+# card-zone-capture Specification
+
+## ADDED Requirements
+
+### Requirement: Cards added to the play area over a card zone are captured by that zone
+When a card is added as a direct child of the play area card zone (played from a deck, added from card search, drawn, or spawned over the network) and its position overlaps a horizontal or vertical card zone inside the play area, the system SHALL move the card into that card zone instead of leaving it loose in the play area.
+
+#### Scenario: Card played from a deck onto a card zone
+- **WHEN** a card is played from a deck to a play area position that overlaps a card zone
+- **THEN** the card is moved into that card zone and becomes a child of the zone rather than of the play area
+
+#### Scenario: Card added to the play area away from any card zone
+- **WHEN** a card is added to the play area at a position that overlaps no card zone
+- **THEN** the card remains in the play area and snaps to the grid as it does today
+
+#### Scenario: Card overlapping multiple card zones
+- **WHEN** a card is added at a position that overlaps more than one card zone
+- **THEN** the card is moved into exactly one of the overlapping zones, chosen deterministically
+
+### Requirement: Capture uses the placeholder movement flow
+The system SHALL perform the capture by creating a placeholder in the target card zone at the layout position corresponding to the card's position, and the card SHALL visibly move to the placeholder before being reparented into the zone.
+
+#### Scenario: Placeholder created at the appropriate location
+- **WHEN** a card added to the play area overlaps a horizontal or vertical card zone
+- **THEN** a placeholder is created inside that zone at the sibling index matching the card's position in the zone's layout
+
+#### Scenario: Card animates to the placeholder
+- **WHEN** the placeholder has been created
+- **THEN** the card moves toward the placeholder position and, upon arrival, is reparented into the card zone at the placeholder's position
+
+### Requirement: Zone add behaviors apply to captured cards
+A card captured into a card zone SHALL receive the same zone add behaviors as a card dropped into the zone by drag-and-drop: the zone's default face preference, the zone's default card action, and multiplayer container synchronization.
+
+#### Scenario: Zone face preference applied
+- **WHEN** a card is captured into a card zone whose default face preference is Down
+- **THEN** the card becomes facedown upon entering the zone
+
+#### Scenario: Capture synchronized in multiplayer
+- **WHEN** a card is captured into a card zone during an online game
+- **THEN** all connected players see the card inside that card zone
+
+### Requirement: Capture does not interfere with in-progress interactions
+The system SHALL NOT capture a card that is static, pending deletion, or already moving to a placeholder from a drag interaction.
+
+#### Scenario: Card already being dragged into a zone
+- **WHEN** a card already has a placeholder from an in-progress drag interaction
+- **THEN** the automatic capture check does not replace or remove that placeholder

--- a/openspec/changes/archive/2026-07-19-auto-move-cards-into-zones/tasks.md
+++ b/openspec/changes/archive/2026-07-19-auto-move-cards-into-zones/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Auto-Move Cards Into Overlapping Card Zones
+
+## 1. CardModel placeholder flow
+
+- [x] 1.1 Add a public method on `CardModel` (implemented as `MoveToOverlappingCardZone()`, which encapsulates guards, zone lookup, placeholder creation, and setting `IsMovingToPlaceHolder = true`) so code outside `CardModel` can start the move-to-placeholder animation
+- [x] 1.2 Verify `FinishMovingToPlaceHolder` reparents the card into the zone and fires the zone's `OnAddCardActions` when the placeholder's parent zone is a Horizontal/Vertical zone (confirmed: reparents to `PlaceHolder.parent`, fires previous zone `OnRemove` and new zone `OnAdd` → face preference, default action, `MoveCardToServer`)
+
+## 2. Zone overlap capture in CardZone.OnAdd
+
+- [x] 2.1 Add a helper on `PlayController` (`FindCardZoneAt(worldPosition)`) that returns the first Horizontal/Vertical card zone in `AllCardZones` (excluding `playAreaCardZone`) whose local rect contains the given world position
+- [x] 2.2 Guard capture (in `CardModel.MoveToOverlappingCardZone()`) when the card `IsStatic`, `ToDelete`, already moving, already has a `PlaceHolderCardZone`, is not parented to the play area, or is a spawned card not owned locally; invoked from `CardZone.OnAdd` (Area zones, before `SnapToGrid()`), `PlayController.AddCardToPlayArea`, and `CardModel.OnStartPlayable` (covers network-spawned cards)
+- [x] 2.3 On overlap: set `PlaceHolderCardZone` to the overlapping zone, call `UpdateLayout(PlaceHolder, transform.position)` to place the placeholder at the correct sibling index, set `IsMovingToPlaceHolder = true`, and return early so `SnapToGrid()` and the play area's add actions are skipped for the captured card
+- [x] 2.4 Ensure no-overlap behavior is unchanged: capture method returns false and the pre-existing code paths (snap to grid, play area add actions) run exactly as before
+
+## 3. Verification
+
+- [x] 3.1 Solo: play a card from a deck onto a horizontal zone and onto a vertical zone; confirm the card animates to a placeholder and lands inside the zone with the zone's face preference and default action applied
+- [x] 3.2 Solo: add a card from card search while a zone is at the drop position; confirm capture; add a card away from any zone; confirm it snaps to grid as before
+- [x] 3.3 Multiplayer (host + client): play a card onto a zone and confirm both players see the card inside the zone
+- [x] 3.4 Drag a card into a zone (existing flow) and confirm drag-and-drop capture still behaves exactly as before
+- [x] 3.5 Run existing play mode/edit mode tests (if any cover play area or card zones) and confirm they pass (PlayMode: 18/18 passed; EditMode: 2/2 passed; Unity 6000.3.15f1 batch mode)

--- a/openspec/specs/card-zone-capture/spec.md
+++ b/openspec/specs/card-zone-capture/spec.md
@@ -1,0 +1,48 @@
+# card-zone-capture Specification
+
+## Purpose
+Automatically capture cards into card zones when a card added to the play area overlaps a zone, including placeholder creation, movement animation, and zone add behaviors, so zones contain whatever cards visibly rest on them.
+## Requirements
+### Requirement: Cards added to the play area over a card zone are captured by that zone
+When a card is added as a direct child of the play area card zone (played from a deck, added from card search, drawn, or spawned over the network) and its position overlaps a horizontal or vertical card zone inside the play area, the system SHALL move the card into that card zone instead of leaving it loose in the play area.
+
+#### Scenario: Card played from a deck onto a card zone
+- **WHEN** a card is played from a deck to a play area position that overlaps a card zone
+- **THEN** the card is moved into that card zone and becomes a child of the zone rather than of the play area
+
+#### Scenario: Card added to the play area away from any card zone
+- **WHEN** a card is added to the play area at a position that overlaps no card zone
+- **THEN** the card remains in the play area and snaps to the grid as it does today
+
+#### Scenario: Card overlapping multiple card zones
+- **WHEN** a card is added at a position that overlaps more than one card zone
+- **THEN** the card is moved into exactly one of the overlapping zones, chosen deterministically
+
+### Requirement: Capture uses the placeholder movement flow
+The system SHALL perform the capture by creating a placeholder in the target card zone at the layout position corresponding to the card's position, and the card SHALL visibly move to the placeholder before being reparented into the zone.
+
+#### Scenario: Placeholder created at the appropriate location
+- **WHEN** a card added to the play area overlaps a horizontal or vertical card zone
+- **THEN** a placeholder is created inside that zone at the sibling index matching the card's position in the zone's layout
+
+#### Scenario: Card animates to the placeholder
+- **WHEN** the placeholder has been created
+- **THEN** the card moves toward the placeholder position and, upon arrival, is reparented into the card zone at the placeholder's position
+
+### Requirement: Zone add behaviors apply to captured cards
+A card captured into a card zone SHALL receive the same zone add behaviors as a card dropped into the zone by drag-and-drop: the zone's default face preference, the zone's default card action, and multiplayer container synchronization.
+
+#### Scenario: Zone face preference applied
+- **WHEN** a card is captured into a card zone whose default face preference is Down
+- **THEN** the card becomes facedown upon entering the zone
+
+#### Scenario: Capture synchronized in multiplayer
+- **WHEN** a card is captured into a card zone during an online game
+- **THEN** all connected players see the card inside that card zone
+
+### Requirement: Capture does not interfere with in-progress interactions
+The system SHALL NOT capture a card that is static, pending deletion, or already moving to a placeholder from a drag interaction.
+
+#### Scenario: Card already being dragged into a zone
+- **WHEN** a card already has a placeholder from an in-progress drag interaction
+- **THEN** the automatic capture check does not replace or remove that placeholder


### PR DESCRIPTION
## What's Changed
- Cards played onto a card zone now automatically move into that zone, instead of sitting loose on top of it
- Works whether the card comes from a deck, card search, or another player, and the card visibly slides into place
- Cards entering a zone this way get the zone's usual behavior, like being flipped facedown, just as if you had dragged them in

🤖 Generated with [Claude Code](https://claude.com/claude-code)