### PR TITLE
Card counts for play area zones

### DIFF
--- a/Assets/Prefabs/CardGameView/Multiplayer/Card Stack.prefab
+++ b/Assets/Prefabs/CardGameView/Multiplayer/Card Stack.prefab
@@ -38,7 +38,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 205211813261613510}
+  - {fileID: 3318835810156797752}
+  - {fileID: 4071995927961036205}
   - {fileID: 3318835810310926618}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -149,7 +150,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 3001253089
+  GlobalObjectIdHash: 3701492064
   InScenePlacedSourceGlobalObjectIdHash: 0
   DeferredDespawnTick: 0
   Ownership: 1
@@ -181,7 +182,7 @@ MonoBehaviour:
   cardModelPrefab: {fileID: 1700305412181862, guid: 3b506588d6983aa468c58a6d81eea204,
     type: 3}
   deckLabel: {fileID: 6350843647229516575}
-  countLabel: {fileID: 6350843648775402011}
+  countLabel: {fileID: 5669688381288800650}
   actionLabel: {fileID: 6350843647083754813}
   topCard: {fileID: 4087591186767669389}
 --- !u!61 &2811030240499207137
@@ -257,43 +258,157 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
---- !u!1 &7768493091142720168
-GameObject:
+--- !u!1001 &3329980547419690874
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 205211813261613510}
-  m_Layer: 5
-  m_Name: Deck-Count Labels
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &205211813261613510
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 4087591186767669377}
+    m_Modifications:
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -60
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6960506880217691888, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_Text
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6960506880217691888, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_FontData.m_Alignment
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7755028453825778640, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_Name
+      value: Count Label
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: eb9a84c1b0b6d25479b907acb118cde9, type: 3}
+--- !u!224 &4071995927961036205 stripped
 RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+    type: 3}
+  m_PrefabInstance: {fileID: 3329980547419690874}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7768493091142720168}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3318835810156797752}
-  - {fileID: 3318835808615085628}
-  m_Father: {fileID: 4087591186767669377}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 60}
-  m_SizeDelta: {x: 0, y: 60}
-  m_Pivot: {x: 0, y: 1}
+--- !u!114 &5669688381288800650 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6960506880217691888, guid: eb9a84c1b0b6d25479b907acb118cde9,
+    type: 3}
+  m_PrefabInstance: {fileID: 3329980547419690874}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &4087591186937709517
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -451,7 +566,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 205211813261613510}
+    m_TransformParent: {fileID: 4087591186767669377}
     m_Modifications:
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
@@ -461,7 +576,7 @@ PrefabInstance:
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_Pivot.y
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
@@ -486,17 +601,17 @@ PrefabInstance:
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: -100
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 60
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
@@ -536,12 +651,12 @@ PrefabInstance:
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -50
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: 60
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
@@ -589,157 +704,6 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6960506880217691888, guid: eb9a84c1b0b6d25479b907acb118cde9,
     type: 3}
   m_PrefabInstance: {fileID: 4087591187620359663}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1001 &4087591188495074539
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 205211813261613510}
-    m_Modifications:
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6960506880217691888, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_Text
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6960506880217691888, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_FontData.m_Alignment
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7755028453825778640, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_Name
-      value: Count Label
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: eb9a84c1b0b6d25479b907acb118cde9, type: 3}
---- !u!224 &3318835808615085628 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-    type: 3}
-  m_PrefabInstance: {fileID: 4087591188495074539}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &6350843648775402011 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6960506880217691888, guid: eb9a84c1b0b6d25479b907acb118cde9,
-    type: 3}
-  m_PrefabInstance: {fileID: 4087591188495074539}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1

--- a/Assets/Prefabs/CardGameView/Multiplayer/Card Zone - Horizontal.prefab
+++ b/Assets/Prefabs/CardGameView/Multiplayer/Card Zone - Horizontal.prefab
@@ -110,7 +110,9 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 31afb6b7aa57adc4d905221f62e956a3, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier:
+  countLabelPrefab: {fileID: 7755028453825778640, guid: eb9a84c1b0b6d25479b907acb118cde9,
+    type: 3}
   type: 1
   allowsFlip: 0
   allowsRotation: 0

--- a/Assets/Prefabs/CardGameView/Multiplayer/Card Zone - Vertical.prefab
+++ b/Assets/Prefabs/CardGameView/Multiplayer/Card Zone - Vertical.prefab
@@ -111,7 +111,9 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 31afb6b7aa57adc4d905221f62e956a3, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier:
+  countLabelPrefab: {fileID: 7755028453825778640, guid: eb9a84c1b0b6d25479b907acb118cde9,
+    type: 3}
   type: 2
   allowsFlip: 0
   allowsRotation: 0

--- a/Assets/Prefabs/CardGameView/Multiplayer/DiceZone.prefab
+++ b/Assets/Prefabs/CardGameView/Multiplayer/DiceZone.prefab
@@ -93,12 +93,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 1610098201
+  GlobalObjectIdHash: 3550046621
   InScenePlacedSourceGlobalObjectIdHash: 0
   DeferredDespawnTick: 0
   Ownership: 1
   AlwaysReplicateAsRoot: 0
   SynchronizeTransform: 1
+  <InScenePlaced>k__BackingField: 0
   ActiveSceneSynchronization: 0
   SceneMigrationSynchronization: 0
   SpawnWithObservers: 1

--- a/Assets/Scripts/Cgs/AotTypeEnforcer.cs
+++ b/Assets/Scripts/Cgs/AotTypeEnforcer.cs
@@ -103,11 +103,11 @@ namespace Cgs
                 cardGame.GamePlayDeckPositions = new List<Float2>();
                 cardGame.GameDefaultCardAction = CardAction.Flip;
                 cardGame.GamePlayPlayerRotations = new List<float>();
-                var gamePlayZone = new GamePlayZone(FacePreference.Any, CardAction.Tap, string.Empty, float2, 0,
+                var gamePlayZone = new GamePlayZone(FacePreference.Any, CardAction.Tap, null, string.Empty, float2, 0f,
                     float2, GamePlayZoneType.Area);
-                var gamePlayZone2 = new GamePlayZone(FacePreference.Up, CardAction.Move, string.Empty, float2, 0,
+                var gamePlayZone2 = new GamePlayZone(FacePreference.Up, CardAction.Move, 0f, string.Empty, float2, 0f,
                     float2, GamePlayZoneType.Area);
-                var gamePlayZone3 = new GamePlayZone(FacePreference.Down, CardAction.Rotate, string.Empty, float2, 0,
+                var gamePlayZone3 = new GamePlayZone(FacePreference.Down, CardAction.Rotate, 1f, string.Empty, float2, 0f,
                     float2, GamePlayZoneType.Area);
                 cardGame.GamePlayZones = new List<GamePlayZone> {gamePlayZone, gamePlayZone2, gamePlayZone3};
                 cardGame.GameStartDecks = new List<DeckUrl>() {deckUrl};

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardStack.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardStack.cs
@@ -646,6 +646,14 @@ namespace Cgs.CardGameView.Multiplayer
             IsTopFaceup = !IsTopFaceup;
         }
 
+        public override void OnNetworkDespawn()
+        {
+            if (IsServer)
+                foreach (var player in FindObjectsByType<CgsNetPlayer>(FindObjectsSortMode.None))
+                    player.ClearCurrentDeck(NetworkObjectId);
+            base.OnNetworkDespawn();
+        }
+
         public override void OnDestroy()
         {
             TopCard?.UnregisterDisplay(this);

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardZone.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardZone.cs
@@ -32,10 +32,15 @@ namespace Cgs.CardGameView.Multiplayer
 
     public class CardZone : CgsNetPlayable, ICardContainer
     {
+        public GameObject countLabelPrefab;
+
         public CardZoneType type;
         public bool allowsFlip;
         public bool allowsRotation;
         public ScrollRect scrollRectContainer;
+
+        private Text _countLabel;
+        private int _countLabelCardCount = -1;
 
         public CardZoneType Type
         {
@@ -92,6 +97,21 @@ namespace Cgs.CardGameView.Multiplayer
         private CardAction _cardAction = CardAction.Move;
         private NetworkVariable<int> _cardActionNetworkVariable;
 
+        // 0 means cards keep their rotation when added, matching CardRotationDefault
+        public float DefaultCardRotation
+        {
+            get => IsSpawned ? _defaultCardRotationNetworkVariable.Value : _defaultCardRotation;
+            set
+            {
+                _defaultCardRotation = value;
+                if (IsSpawned)
+                    _defaultCardRotationNetworkVariable.Value = value;
+            }
+        }
+
+        private float _defaultCardRotation;
+        private NetworkVariable<float> _defaultCardRotationNetworkVariable;
+
         public bool DoesImmediatelyRelease { get; set; }
 
         public UnityAction OnLayout { get; set; }
@@ -105,6 +125,7 @@ namespace Cgs.CardGameView.Multiplayer
             _nameNetworkVariable = new NetworkVariable<CgsNetString>();
             _facePreferenceNetworkVariable = new NetworkVariable<int>();
             _cardActionNetworkVariable = new NetworkVariable<int>();
+            _defaultCardRotationNetworkVariable = new NetworkVariable<float>();
         }
 
         protected override void OnNetworkSpawnPlayable()
@@ -115,12 +136,14 @@ namespace Cgs.CardGameView.Multiplayer
                 _nameNetworkVariable.Value = _name;
                 _facePreferenceNetworkVariable.Value = (int)_facePreference;
                 _cardActionNetworkVariable.Value = (int)_cardAction;
+                _defaultCardRotationNetworkVariable.Value = _defaultCardRotation;
             }
 
             type = (CardZoneType)_typeNetworkVariable.Value;
             _name = _nameNetworkVariable.Value;
             _facePreference = (FacePreference)_facePreferenceNetworkVariable.Value;
             _cardAction = (CardAction)_cardActionNetworkVariable.Value;
+            _defaultCardRotation = _defaultCardRotationNetworkVariable.Value;
         }
 
         protected override void OnStartPlayable()
@@ -158,6 +181,8 @@ namespace Cgs.CardGameView.Multiplayer
             scrollRectContainer = PlayController.Instance.playArea;
             DoesImmediatelyRelease = true;
 
+            CreateCountLabel();
+
             OnAddCardActions.Add((cardZone, cardModel) =>
             {
                 cardModel.IsFacedown = cardZone.DefaultFace switch
@@ -168,9 +193,58 @@ namespace Cgs.CardGameView.Multiplayer
                 };
                 cardModel.DefaultAction = CardActionPanel.CardActionDictionary[cardZone.DefaultAction];
                 cardModel.SecondaryDragAction = cardModel.UpdateParentCardZoneScrollRect;
+                if (cardZone.DefaultCardRotation != 0)
+                {
+                    // Set the transform directly so this rotation does not animate,
+                    // since MoveCardToServer may immediately read the final rotation from the transform
+                    cardModel.transform.localRotation = Quaternion.Euler(0, 0, cardZone.DefaultCardRotation);
+                    cardModel.Rotation = cardModel.transform.localRotation;
+                }
             });
 
             StartCoroutine(WaitToAddMoveCardToServer());
+        }
+
+        // Show the count of cards in this zone, like the count labels of card stacks and dice zones
+        private void CreateCountLabel()
+        {
+            if (countLabelPrefab == null)
+                return;
+
+            var countLabelGameObject = Instantiate(countLabelPrefab, transform);
+            // The label is not a card, so the layout group and the card raycasts must both ignore it
+            countLabelGameObject.GetOrAddComponent<LayoutElement>().ignoreLayout = true;
+            var countLabelRectTransform = (RectTransform)countLabelGameObject.transform;
+            countLabelRectTransform.anchorMin = new Vector2(0.5f, 0);
+            countLabelRectTransform.anchorMax = new Vector2(0.5f, 0);
+            countLabelRectTransform.pivot = new Vector2(0.5f, 0);
+            countLabelRectTransform.anchoredPosition = new Vector2(0, -60);
+            countLabelRectTransform.sizeDelta = new Vector2(100, 60);
+            _countLabel = countLabelGameObject.GetComponent<Text>();
+            _countLabel.raycastTarget = false;
+            _countLabel.text = "0";
+        }
+
+        protected override void OnUpdatePlayable()
+        {
+            if (_countLabel == null)
+                return;
+
+            var cardCount = 0;
+            for (var i = 0; i < transform.childCount; i++)
+                if (transform.GetChild(i).TryGetComponent<CardModel>(out _))
+                    cardCount++;
+            if (cardCount != _countLabelCardCount)
+            {
+                _countLabelCardCount = cardCount;
+                _countLabel.text = cardCount.ToString();
+            }
+
+            // Cards in this zone are ordered by sibling index, which is synced across the network,
+            // so the label must stay last to keep card sibling indices consistent on all clients
+            var countLabelTransform = _countLabel.transform;
+            if (countLabelTransform.GetSiblingIndex() != transform.childCount - 1)
+                countLabelTransform.SetAsLastSibling();
         }
 
         private IEnumerator WaitToAddMoveCardToServer()
@@ -273,13 +347,14 @@ namespace Cgs.CardGameView.Multiplayer
             } && !card.IsBackFaceCard;
 
             var isCardShared = SharePreference.Share == CardGameManager.Current.DeckSharePreference;
+            var rotation = Quaternion.Euler(0, 0, DefaultCardRotation);
             if (CgsNetManager.Instance.IsOnline && CgsNetManager.Instance.LocalPlayer != null)
                 CgsNetManager.Instance.LocalPlayer.RequestNewCardInZone(this, card.Id, Vector2.zero,
-                    Quaternion.identity, isFacedown, isCardShared);
+                    rotation, isFacedown, isCardShared);
             else
             {
                 var cardModel = PlayController.Instance.CreateCardModel(gameObject, card.Id, Vector2.zero,
-                    Quaternion.identity, isFacedown, isCardShared);
+                    rotation, isFacedown, isCardShared);
                 OnAdd(cardModel);
             }
         }

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardZone.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardZone.cs
@@ -225,10 +225,19 @@ namespace Cgs.CardGameView.Multiplayer
             _countLabel.text = "0";
         }
 
+        private bool _isCountDirty = true;
+
+        private void OnTransformChildrenChanged()
+        {
+            _isCountDirty = true;
+        }
+
         protected override void OnUpdatePlayable()
         {
-            if (_countLabel == null)
+            if (_countLabel == null || !_isCountDirty)
                 return;
+
+            _isCountDirty = false;
 
             var cardCount = 0;
             for (var i = 0; i < transform.childCount; i++)
@@ -246,7 +255,6 @@ namespace Cgs.CardGameView.Multiplayer
             if (countLabelTransform.GetSiblingIndex() != transform.childCount - 1)
                 countLabelTransform.SetAsLastSibling();
         }
-
         private IEnumerator WaitToAddMoveCardToServer()
         {
             while (CgsNetManager.Instance.LocalPlayer == null)

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardZone.cs.meta
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardZone.cs.meta
@@ -4,7 +4,9 @@ timeCreated: 1502481214
 licenseType: Free
 MonoImporter:
   serializedVersion: 2
-  defaultReferences: []
+  defaultReferences:
+  - countLabelPrefab: {fileID: 7755028453825778640, guid: eb9a84c1b0b6d25479b907acb118cde9,
+      type: 3}
   executionOrder: 0
   icon: {instanceID: 0}
   userData: 

--- a/Assets/Scripts/Cgs/Play/Drawer/CardDrawer.cs
+++ b/Assets/Scripts/Cgs/Play/Drawer/CardDrawer.cs
@@ -243,7 +243,17 @@ namespace Cgs.Play.Drawer
             if (selectedIndex >= 0 && selectedIndex < allCardStacks.Count)
                 cardStackDropdown.value = selectedIndex;
             else if (allCardStacks.Count > 0)
+            {
+                // The current deck is unset or its stack is gone, so fall back to the first stack and
+                // sync the current deck to it, since the current deck should always match this dropdown.
+                // Skip the sync while a new deck's card stack has not yet spawned locally.
                 cardStackDropdown.value = 0;
+                var localPlayer = CgsNetManager.Instance != null && CgsNetManager.Instance.IsOnline
+                    ? CgsNetManager.Instance.LocalPlayer
+                    : null;
+                if (localPlayer == null || !localPlayer.HasUnresolvedCurrentDeck)
+                    SetCurrentDeck(allCardStacks[0]);
+            }
 
             cardStackDropdown.RefreshShownValue();
 
@@ -263,18 +273,21 @@ namespace Cgs.Play.Drawer
             if (cardStackIndex < 0 || cardStackIndex >= allCardStacks.Count)
                 return;
 
-            var selectedStack = allCardStacks[cardStackIndex];
+            SetCurrentDeck(allCardStacks[cardStackIndex]);
+        }
 
+        private static void SetCurrentDeck(CardStack cardStack)
+        {
             if (CgsNetManager.Instance != null && CgsNetManager.Instance.IsOnline &&
                 CgsNetManager.Instance.LocalPlayer != null)
             {
-                var networkObject = selectedStack.GetComponent<NetworkObject>();
+                var networkObject = cardStack.GetComponent<NetworkObject>();
                 if (networkObject != null)
                     CgsNetManager.Instance.LocalPlayer.RequestSetCurrentDeck(networkObject);
             }
             else
             {
-                PlayController.Instance.CurrentDeckStack = selectedStack;
+                PlayController.Instance.CurrentDeckStack = cardStack;
             }
         }
 

--- a/Assets/Scripts/Cgs/Play/Multiplayer/CgsNetPlayer.cs
+++ b/Assets/Scripts/Cgs/Play/Multiplayer/CgsNetPlayer.cs
@@ -27,6 +27,7 @@ namespace Cgs.Play.Multiplayer
         public Vector2 Size;
         public string Face;
         public string Action;
+        public float DefaultCardRotation;
 #pragma warning restore S1104
 
         public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
@@ -38,6 +39,7 @@ namespace Cgs.Play.Multiplayer
             serializer.SerializeValue(ref Size);
             serializer.SerializeValue(ref Face);
             serializer.SerializeValue(ref Action);
+            serializer.SerializeValue(ref DefaultCardRotation);
         }
     }
 

--- a/Assets/Scripts/Cgs/Play/Multiplayer/CgsNetPlayer.cs
+++ b/Assets/Scripts/Cgs/Play/Multiplayer/CgsNetPlayer.cs
@@ -104,6 +104,16 @@ namespace Cgs.Play.Multiplayer
 
         private NetworkVariable<NetworkObjectReference> _currentDeck;
 
+        // True when a current deck reference is set, but its card stack has not (yet) spawned locally
+        public bool HasUnresolvedCurrentDeck
+        {
+            get
+            {
+                var currentDeckId = _currentDeck.Value.NetworkObjectId;
+                return currentDeckId != 0 && currentDeckId != ulong.MaxValue && CurrentDeck == null;
+            }
+        }
+
         public bool IsDeckShared
         {
             get => _isDeckShared.Value;
@@ -425,6 +435,13 @@ namespace Cgs.Play.Multiplayer
         {
             if (PlayController.Instance != null && PlayController.Instance.drawer != null)
                 PlayController.Instance.drawer.RefreshCardStackDropdown();
+        }
+
+        // Server-only: un-references a despawning card stack, so the current deck does not go permanently stale
+        public void ClearCurrentDeck(ulong despawnedNetworkObjectId)
+        {
+            if (IsServer && _currentDeck.Value.NetworkObjectId == despawnedNetworkObjectId)
+                CurrentDeck = null;
         }
 
         public void RequestNewCardStack(string stackName, IEnumerable<UnityCard> cards, Vector2 position,

--- a/Assets/Scripts/Cgs/Play/PlayController.cs
+++ b/Assets/Scripts/Cgs/Play/PlayController.cs
@@ -1046,6 +1046,7 @@ namespace Cgs.Play
             CardGameManager.Instance.Messenger.Prompt(RestartPrompt, Restart);
         }
 
+        [UsedImplicitly]
         public void BackToMainMenu()
         {
             StopNetworking();

--- a/Assets/Scripts/Cgs/Play/PlayController.cs
+++ b/Assets/Scripts/Cgs/Play/PlayController.cs
@@ -909,7 +909,8 @@ namespace Cgs.Play
                 Size = CardGameManager.PixelsPerInch *
                        new Vector2(gamePlayZone.Size.X, gamePlayZone.Size.Y),
                 Face = gamePlayZone.Face.ToString(),
-                Action = cardAction.ToString()
+                Action = cardAction.ToString(),
+                DefaultCardRotation = gamePlayZone.DefaultCardRotation
             };
 
             if (CgsNetManager.Instance.IsOnline && CgsNetManager.Instance.LocalPlayer != null)
@@ -943,6 +944,7 @@ namespace Cgs.Play
                     cardZone.DefaultFace = facePreference;
                 if (Enum.TryParse(zone.Action, true, out CardAction cardAction))
                     cardZone.DefaultAction = cardAction;
+                cardZone.DefaultCardRotation = zone.DefaultCardRotation;
 
                 return playable;
             }


### PR DESCRIPTION
## What's Changed
- Card zones in the play area now show how many cards they hold
- Card stack counts now appear below the stack, matching the zone counts
- Games can now set cards to automatically rotate when placed in a zone
- Fixed the selected deck getting lost after loading a second deck, emptying a deck, or restarting; dealing now always uses the deck shown in the hand drawer dropdown