### PR TITLE
Copilot/fix GitHub actions check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1193,20 +1193,28 @@ jobs:
           ANNOUNCEMENT: ${{ steps.prepare.outputs.ANNOUNCEMENT }}
         run: |
           python3 - <<'EOF'
-          import json, os, urllib.request, datetime
+          import json, os, sys, urllib.request, urllib.error, datetime
           identifier = os.environ['BLUESKY_IDENTIFIER']
           password = os.environ['BLUESKY_PASSWORD']
           text = os.environ['ANNOUNCEMENT']
-          session_body = json.dumps({'identifier': identifier, 'password': password}).encode()
-          req = urllib.request.Request('https://bsky.social/xrpc/com.atproto.server.createSession',
-            data=session_body, headers={'Content-Type': 'application/json'})
-          session = json.loads(urllib.request.urlopen(req).read())
-          token, did = session['accessJwt'], session['did']
-          now = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.000Z')
+          try:
+            session_body = json.dumps({'identifier': identifier, 'password': password}).encode()
+            req = urllib.request.Request('https://bsky.social/xrpc/com.atproto.server.createSession',
+              data=session_body, headers={'Content-Type': 'application/json'})
+            session = json.loads(urllib.request.urlopen(req).read())
+            token, did = session['accessJwt'], session['did']
+          except (urllib.error.HTTPError, urllib.error.URLError) as e:
+            print(f'Bluesky authentication failed: {e}', file=sys.stderr)
+            sys.exit(1)
+          now = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.000Z')
           record = {'$type': 'app.bsky.feed.post', 'text': text, 'createdAt': now}
           post_body = json.dumps({'repo': did, 'collection': 'app.bsky.feed.post', 'record': record}).encode()
-          req2 = urllib.request.Request('https://bsky.social/xrpc/com.atproto.repo.createRecord',
-            data=post_body, headers={'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'})
-          res = json.loads(urllib.request.urlopen(req2).read())
-          print('Posted to Bluesky:', res.get('uri', res))
+          try:
+            req2 = urllib.request.Request('https://bsky.social/xrpc/com.atproto.repo.createRecord',
+              data=post_body, headers={'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'})
+            res = json.loads(urllib.request.urlopen(req2).read())
+            print('Posted to Bluesky:', res.get('uri', res))
+          except (urllib.error.HTTPError, urllib.error.URLError) as e:
+            print(f'Bluesky post failed: {e}', file=sys.stderr)
+            sys.exit(1)
           EOF

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1186,8 +1186,27 @@ jobs:
         with:
           args: ${{ steps.prepare.outputs.ANNOUNCEMENT }}
       - name: Bluesky Announcement
-        uses: myConsciousness/bluesky-post@v6
-        with:
-          text:  ${{ steps.prepare.outputs.ANNOUNCEMENT }}
-          identifier: ${{ secrets.BLUESKY_IDENTIFIER }}
-          password: ${{ secrets.BLUESKY_PASSWORD }}
+        shell: bash
+        env:
+          BLUESKY_IDENTIFIER: ${{ secrets.BLUESKY_IDENTIFIER }}
+          BLUESKY_PASSWORD: ${{ secrets.BLUESKY_PASSWORD }}
+          ANNOUNCEMENT: ${{ steps.prepare.outputs.ANNOUNCEMENT }}
+        run: |
+          python3 - <<'EOF'
+          import json, os, urllib.request, datetime
+          identifier = os.environ['BLUESKY_IDENTIFIER']
+          password = os.environ['BLUESKY_PASSWORD']
+          text = os.environ['ANNOUNCEMENT']
+          session_body = json.dumps({'identifier': identifier, 'password': password}).encode()
+          req = urllib.request.Request('https://bsky.social/xrpc/com.atproto.server.createSession',
+            data=session_body, headers={'Content-Type': 'application/json'})
+          session = json.loads(urllib.request.urlopen(req).read())
+          token, did = session['accessJwt'], session['did']
+          now = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.000Z')
+          record = {'$type': 'app.bsky.feed.post', 'text': text, 'createdAt': now}
+          post_body = json.dumps({'repo': did, 'collection': 'app.bsky.feed.post', 'record': record}).encode()
+          req2 = urllib.request.Request('https://bsky.social/xrpc/com.atproto.repo.createRecord',
+            data=post_body, headers={'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'})
+          res = json.loads(urllib.request.urlopen(req2).read())
+          print('Posted to Bluesky:', res.get('uri', res))
+          EOF

--- a/.github/workflows/release_announcement.yml
+++ b/.github/workflows/release_announcement.yml
@@ -39,8 +39,27 @@ jobs:
           args: ${{ steps.prepare.outputs.ANNOUNCEMENT }}
       - name: Bluesky Announcement
         if: github.ref == 'refs/heads/main'
-        uses: myConsciousness/bluesky-post@v6
-        with:
-          text:  ${{ steps.prepare.outputs.ANNOUNCEMENT }}
-          identifier: ${{ secrets.BLUESKY_IDENTIFIER }}
-          password: ${{ secrets.BLUESKY_PASSWORD }}
+        shell: bash
+        env:
+          BLUESKY_IDENTIFIER: ${{ secrets.BLUESKY_IDENTIFIER }}
+          BLUESKY_PASSWORD: ${{ secrets.BLUESKY_PASSWORD }}
+          ANNOUNCEMENT: ${{ steps.prepare.outputs.ANNOUNCEMENT }}
+        run: |
+          python3 - <<'EOF'
+          import json, os, urllib.request, datetime
+          identifier = os.environ['BLUESKY_IDENTIFIER']
+          password = os.environ['BLUESKY_PASSWORD']
+          text = os.environ['ANNOUNCEMENT']
+          session_body = json.dumps({'identifier': identifier, 'password': password}).encode()
+          req = urllib.request.Request('https://bsky.social/xrpc/com.atproto.server.createSession',
+            data=session_body, headers={'Content-Type': 'application/json'})
+          session = json.loads(urllib.request.urlopen(req).read())
+          token, did = session['accessJwt'], session['did']
+          now = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.000Z')
+          record = {'$type': 'app.bsky.feed.post', 'text': text, 'createdAt': now}
+          post_body = json.dumps({'repo': did, 'collection': 'app.bsky.feed.post', 'record': record}).encode()
+          req2 = urllib.request.Request('https://bsky.social/xrpc/com.atproto.repo.createRecord',
+            data=post_body, headers={'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'})
+          res = json.loads(urllib.request.urlopen(req2).read())
+          print('Posted to Bluesky:', res.get('uri', res))
+          EOF

--- a/.github/workflows/release_announcement.yml
+++ b/.github/workflows/release_announcement.yml
@@ -46,20 +46,28 @@ jobs:
           ANNOUNCEMENT: ${{ steps.prepare.outputs.ANNOUNCEMENT }}
         run: |
           python3 - <<'EOF'
-          import json, os, urllib.request, datetime
+          import json, os, sys, urllib.request, urllib.error, datetime
           identifier = os.environ['BLUESKY_IDENTIFIER']
           password = os.environ['BLUESKY_PASSWORD']
           text = os.environ['ANNOUNCEMENT']
-          session_body = json.dumps({'identifier': identifier, 'password': password}).encode()
-          req = urllib.request.Request('https://bsky.social/xrpc/com.atproto.server.createSession',
-            data=session_body, headers={'Content-Type': 'application/json'})
-          session = json.loads(urllib.request.urlopen(req).read())
-          token, did = session['accessJwt'], session['did']
-          now = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.000Z')
+          try:
+            session_body = json.dumps({'identifier': identifier, 'password': password}).encode()
+            req = urllib.request.Request('https://bsky.social/xrpc/com.atproto.server.createSession',
+              data=session_body, headers={'Content-Type': 'application/json'})
+            session = json.loads(urllib.request.urlopen(req).read())
+            token, did = session['accessJwt'], session['did']
+          except (urllib.error.HTTPError, urllib.error.URLError) as e:
+            print(f'Bluesky authentication failed: {e}', file=sys.stderr)
+            sys.exit(1)
+          now = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.000Z')
           record = {'$type': 'app.bsky.feed.post', 'text': text, 'createdAt': now}
           post_body = json.dumps({'repo': did, 'collection': 'app.bsky.feed.post', 'record': record}).encode()
-          req2 = urllib.request.Request('https://bsky.social/xrpc/com.atproto.repo.createRecord',
-            data=post_body, headers={'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'})
-          res = json.loads(urllib.request.urlopen(req2).read())
-          print('Posted to Bluesky:', res.get('uri', res))
+          try:
+            req2 = urllib.request.Request('https://bsky.social/xrpc/com.atproto.repo.createRecord',
+              data=post_body, headers={'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'})
+            res = json.loads(urllib.request.urlopen(req2).read())
+            print('Posted to Bluesky:', res.get('uri', res))
+          except (urllib.error.HTTPError, urllib.error.URLError) as e:
+            print(f'Bluesky post failed: {e}', file=sys.stderr)
+            sys.exit(1)
           EOF


### PR DESCRIPTION
This pull request updates how Bluesky announcements are posted in the GitHub Actions workflows. Instead of using the `myConsciousness/bluesky-post` action, it now uses a custom inline Python script to interact directly with the Bluesky API for posting announcements. This change gives more control over the authentication and posting process and removes the dependency on the third-party GitHub Action.

**Workflow automation changes:**

* Replaces the `myConsciousness/bluesky-post` GitHub Action with a custom inline Python script in both `.github/workflows/main.yml` and `.github/workflows/release_announcement.yml` for posting Bluesky announcements. The script performs authentication and posting directly via the Bluesky API, using environment variables for credentials and the announcement text. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L1189-R1220) [[2]](diffhunk://#diff-dc5b3b153bd1860154aed98ceb816bc5c8d2d62b22529cb311d3d351a04edbe0L42-R73)