### PR TITLE
Fix deck editor navigation for horizontal layout

### DIFF
--- a/Assets/Scenes/DeckEditor.unity
+++ b/Assets/Scenes/DeckEditor.unity
@@ -319,6 +319,12 @@ MonoBehaviour:
   - {fileID: 3237348216148718022}
   - {fileID: 978520244}
   scrollRect: {fileID: 1956326059}
+  verticalScrollAreas:
+  - {fileID: 101617381}
+  - {fileID: 1881857421}
+  horizontalScrollAreas:
+  - {fileID: 207323834}
+  - {fileID: 2116385789}
   nameText: {fileID: 1211921541}
   countText: {fileID: 604367886}
   searchResults: {fileID: 62766703}
@@ -537,6 +543,18 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 2848342772243254879, guid: 30c175fe170c9e0459ee166821450a03,
     type: 3}
   m_PrefabInstance: {fileID: 66669952}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &101617381 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3237348215989687736, guid: 1200650e6b8967b43ac73718e6e1fa87,
+    type: 3}
+  m_PrefabInstance: {fileID: 1060735687}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &207323834 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3237348215989687736, guid: 1200650e6b8967b43ac73718e6e1fa87,
+    type: 3}
+  m_PrefabInstance: {fileID: 3237348216148718021}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &208227996
 PrefabInstance:
@@ -767,196 +785,6 @@ RectTransform:
   m_AnchoredPosition: {x: -262.5, y: 0}
   m_SizeDelta: {x: -525, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1001 &2059094881
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 248285009}
-    m_Modifications:
-    - target: {fileID: 2431982676670645471, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_Sprite
-      value:
-      objectReference: {fileID: 21300000, guid: ec423b2ae726af54f8a6fd9299aa1885,
-        type: 3}
-    - target: {fileID: 2431982676814096016, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096016, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096016, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value:
-      objectReference: {fileID: 62766704}
-    - target: {fileID: 2431982676814096016, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096016, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: ToggleLayout
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096016, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: Cgs.Decks.DeckEditor, Cgs
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096016, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096018, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_Name
-      value: Sort Button
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 80
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 80
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7535159269639633972, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: tooltip
-      value: Toggle Layout
-      objectReference: {fileID: 0}
-    - target: {fileID: 7535159269639633972, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: isBelow
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7535159269639633972, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: avoidOverlap
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7535159269639633972, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-        type: 3}
-      propertyPath: inputActionId
-      value: Cards/Sort
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 06f7fede5f8506f4aaaca01736a75a9b, type: 3}
---- !u!224 &2059094882 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
-    type: 3}
-  m_PrefabInstance: {fileID: 2059094881}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &336578660
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2110,7 +1938,7 @@ MonoBehaviour:
     type: 3}
   m_PrefabInstance: {fileID: 978520242}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 2116385789}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 29e5f42c2967f4040977bc18d0b016e8, type: 3}
@@ -2524,7 +2352,7 @@ PrefabInstance:
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: -190
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
@@ -2569,7 +2397,7 @@ PrefabInstance:
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 15
+      value: -35
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
@@ -3615,6 +3443,12 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1832886586}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1881857421 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3237348215989687736, guid: 1200650e6b8967b43ac73718e6e1fa87,
+    type: 3}
+  m_PrefabInstance: {fileID: 513307671}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1937820141
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3896,6 +3730,202 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isBlocker: 0
+--- !u!1001 &2059094881
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 248285009}
+    m_Modifications:
+    - target: {fileID: 2431982676670645471, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: ec423b2ae726af54f8a6fd9299aa1885,
+        type: 3}
+    - target: {fileID: 2431982676814096016, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096016, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096016, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 62766704}
+    - target: {fileID: 2431982676814096016, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096016, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: ToggleLayout
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096016, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: Cgs.Decks.DeckEditor, Cgs
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096016, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096018, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_Name
+      value: Sort Button
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -80
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7535159269639633972, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: isBelow
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7535159269639633972, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: tooltip
+      value: Pivot
+      objectReference: {fileID: 0}
+    - target: {fileID: 7535159269639633972, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: avoidOverlap
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7535159269639633972, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+        type: 3}
+      propertyPath: inputActionId
+      value: Cards/Sort
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 06f7fede5f8506f4aaaca01736a75a9b, type: 3}
+--- !u!224 &2059094882 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2431982676814096019, guid: 06f7fede5f8506f4aaaca01736a75a9b,
+    type: 3}
+  m_PrefabInstance: {fileID: 2059094881}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2116385789 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3237348215989687736, guid: 1200650e6b8967b43ac73718e6e1fa87,
+    type: 3}
+  m_PrefabInstance: {fileID: 978520242}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &114896128118158155 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4504567957991627913, guid: 40851ef068004064882ab1e3c8ee1b9e,
@@ -4047,7 +4077,7 @@ MonoBehaviour:
     type: 3}
   m_PrefabInstance: {fileID: 3237348216148718021}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 207323834}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 29e5f42c2967f4040977bc18d0b016e8, type: 3}

--- a/Assets/Scripts/Cgs/Decks/DeckCardSelector.cs
+++ b/Assets/Scripts/Cgs/Decks/DeckCardSelector.cs
@@ -114,7 +114,21 @@ namespace Cgs.Decks
             }
         }
 
-        private void SelectEditorLeft()
+        // CardModels is ordered along each zone: left-to-right within horizontal zones,
+        // top-to-bottom within vertical zones, so the stride for each direction depends on the layout
+        private void SelectEditorLeft() =>
+            SelectEditorPrevious(editor.IsHorizontalLayout ? DeckEditor.CardsPerZoneVertical : 1);
+
+        private void SelectEditorRight() =>
+            SelectEditorNext(editor.IsHorizontalLayout ? DeckEditor.CardsPerZoneVertical : 1);
+
+        private void SelectEditorDown() =>
+            SelectEditorNext(editor.IsHorizontalLayout ? 1 : DeckEditor.CardsPerZoneHorizontal);
+
+        private void SelectEditorUp() =>
+            SelectEditorPrevious(editor.IsHorizontalLayout ? 1 : DeckEditor.CardsPerZoneHorizontal);
+
+        private void SelectEditorPrevious(int stride)
         {
             if (IsBlocked || EventSystem.current.alreadySelecting)
                 return;
@@ -130,11 +144,11 @@ namespace Cgs.Decks
             {
                 if (editorCardModels[i] != CardViewer.Instance.SelectedCardModel)
                     continue;
-                i--;
-                if (i < 0)
-                    i = editorCardModels.Count - 1;
-                EventSystem.current.SetSelectedGameObject(editorCardModels[i].gameObject);
-                editor.FocusScrollRectOn(editorCardModels[i]);
+                var previous = i - stride;
+                if (previous < 0)
+                    previous = editorCardModels.Count - 1;
+                EventSystem.current.SetSelectedGameObject(editorCardModels[previous].gameObject);
+                editor.FocusScrollRectOn(editorCardModels[previous]);
                 return;
             }
 
@@ -144,7 +158,7 @@ namespace Cgs.Decks
                 CardViewer.Instance.IsVisible = true;
         }
 
-        private void SelectEditorRight()
+        private void SelectEditorNext(int stride)
         {
             if (IsBlocked || EventSystem.current.alreadySelecting)
                 return;
@@ -160,76 +174,16 @@ namespace Cgs.Decks
             {
                 if (editorCardModels[i] != CardViewer.Instance.SelectedCardModel)
                     continue;
-                i++;
-                if (i == editorCardModels.Count)
-                    i = 0;
-                EventSystem.current.SetSelectedGameObject(editorCardModels[i].gameObject);
-                editor.FocusScrollRectOn(editorCardModels[i]);
+                var next = i + stride;
+                if (next >= editorCardModels.Count)
+                    next = 0;
+                EventSystem.current.SetSelectedGameObject(editorCardModels[next].gameObject);
+                editor.FocusScrollRectOn(editorCardModels[next]);
                 return;
             }
 
             EventSystem.current.SetSelectedGameObject(editorCardModels[0].gameObject);
             editor.FocusScrollRectOn(editorCardModels[0]);
-            if (CardViewer.Instance != null && CardViewer.Instance.SelectedCardModel != null)
-                CardViewer.Instance.IsVisible = true;
-        }
-
-        private void SelectEditorDown()
-        {
-            if (IsBlocked || EventSystem.current.alreadySelecting)
-                return;
-
-            var editorCardModels = editor.CardModels;
-            if (editorCardModels.Count < 1)
-            {
-                EventSystem.current.SetSelectedGameObject(null);
-                return;
-            }
-
-            for (var i = 0; i < editorCardModels.Count; i++)
-            {
-                if (editorCardModels[i] != CardViewer.Instance.SelectedCardModel)
-                    continue;
-                i += DeckEditor.CardsPerZoneHorizontal;
-                if (i >= editorCardModels.Count)
-                    i = 0;
-                EventSystem.current.SetSelectedGameObject(editorCardModels[i].gameObject);
-                editor.FocusScrollRectOn(editorCardModels[i]);
-                return;
-            }
-
-            EventSystem.current.SetSelectedGameObject(editorCardModels[0].gameObject);
-            editor.FocusScrollRectOn(editorCardModels[0]);
-            if (CardViewer.Instance != null && CardViewer.Instance.SelectedCardModel != null)
-                CardViewer.Instance.IsVisible = true;
-        }
-
-        private void SelectEditorUp()
-        {
-            if (IsBlocked || EventSystem.current.alreadySelecting)
-                return;
-
-            var editorCardModels = editor.CardModels;
-            if (editorCardModels.Count < 1)
-            {
-                EventSystem.current.SetSelectedGameObject(null);
-                return;
-            }
-
-            for (var i = editorCardModels.Count - 1; i >= 0; i--)
-            {
-                if (editorCardModels[i] != CardViewer.Instance.SelectedCardModel)
-                    continue;
-                i -= DeckEditor.CardsPerZoneHorizontal;
-                if (i < 0)
-                    i = editorCardModels.Count - 1;
-                EventSystem.current.SetSelectedGameObject(editorCardModels[i].gameObject);
-                editor.FocusScrollRectOn(editorCardModels[i]);
-                return;
-            }
-
-            EventSystem.current.SetSelectedGameObject(editorCardModels[^1].gameObject);
-            editor.FocusScrollRectOn(editorCardModels[^1]);
             if (CardViewer.Instance != null && CardViewer.Instance.SelectedCardModel != null)
                 CardViewer.Instance.IsVisible = true;
         }
@@ -248,7 +202,7 @@ namespace Cgs.Decks
         private void SelectPrevious()
         {
             if (IsSelectedCardInDeck)
-                SelectEditorLeft();
+                SelectEditorPrevious(1);
             else
                 SelectResultsUp();
         }
@@ -273,7 +227,7 @@ namespace Cgs.Decks
         private void SelectNext()
         {
             if (IsSelectedCardInDeck)
-                SelectEditorRight();
+                SelectEditorNext(1);
             else
                 SelectResultsDown();
         }

--- a/Assets/Scripts/Cgs/Decks/DeckEditor.cs
+++ b/Assets/Scripts/Cgs/Decks/DeckEditor.cs
@@ -46,6 +46,13 @@ namespace Cgs.Decks
         public RectTransform layoutContent;
         public List<CardDropArea> dropZones;
         public ScrollRect scrollRect;
+
+        // top/bottom edge areas that scroll the deck while dragging a card, for the vertical scrollbar layout
+        public List<GameObject> verticalScrollAreas;
+
+        // left/right edge areas that scroll the deck while dragging a card, for the horizontal scrollbar layout
+        public List<GameObject> horizontalScrollAreas;
+
         public Text nameText;
         public Text countText;
         public SearchResults searchResults;
@@ -60,7 +67,7 @@ namespace Cgs.Decks
             { 0, 4 }, { 1, 8 }, { 2, 12 }, { 3, 16 }
         };
 
-        private static int CardsPerZoneVertical =>
+        public static int CardsPerZoneVertical =>
             Mathf.FloorToInt(CardPrefabHeight / (CardGameManager.PixelsPerInch * CardGameManager.Current.CardSize.Y) *
                              ResolutionIndexToCardsPerColumn[ResolutionManager.ResolutionIndex]);
 
@@ -124,6 +131,8 @@ namespace Cgs.Decks
                                   CardGameManager.Instance.ModalCanvas != null || searchResults.inputField.isFocused;
 
         // false: horizontal card zones with a vertical scrollbar; true: vertical card zones with a horizontal scrollbar
+        public bool IsHorizontalLayout => _isHorizontalLayout;
+
         private bool _isHorizontalLayout;
 
         private void OnEnable()
@@ -519,12 +528,17 @@ namespace Cgs.Decks
             if (scrollRect.verticalScrollbar != null)
                 scrollRect.verticalScrollbar.gameObject.SetActive(!_isHorizontalLayout);
 
+            foreach (var verticalScrollArea in verticalScrollAreas)
+                verticalScrollArea.SetActive(!_isHorizontalLayout);
+            foreach (var horizontalScrollArea in horizontalScrollAreas)
+                horizontalScrollArea.SetActive(_isHorizontalLayout);
+
             var layoutGroup = layoutContent.GetComponent<HorizontalOrVerticalLayoutGroup>();
             if (layoutGroup != null)
             {
-                // Disable before the deferred Destroy so the old group cannot fight the new one this frame
-                layoutGroup.enabled = false;
-                Destroy(layoutGroup);
+                // LayoutGroup is [DisallowMultipleComponent], so the old group must be gone
+                // before AddComponent below, or AddComponent returns null
+                DestroyImmediate(layoutGroup);
             }
 
             if (_isHorizontalLayout)


### PR DESCRIPTION
## What's Changed
- Arrow keys now move card selection in the correct direction in the deck editor when using the horizontal layout
- The edges of the deck editor now scroll the deck correctly while dragging a card in both layouts
- Fixed an issue where switching deck editor layouts could fail to rearrange the cards