### PR TITLE
Auto-detect card image orientation

### DIFF
--- a/Assets/InputSystem_Actions.inputactions
+++ b/Assets/InputSystem_Actions.inputactions
@@ -1150,7 +1150,7 @@
                 {
                     "name": "",
                     "id": "171e9597-1270-43f6-b8da-0a3c8b28eadb",
-                    "path": "<Keyboard>/p",
+                    "path": "<Keyboard>/m",
                     "interactions": "",
                     "processors": "",
                     "groups": ";Keyboard&Mouse",

--- a/Assets/Prefabs/CardGameView/Viewer/Card Docked Viewer.prefab
+++ b/Assets/Prefabs/CardGameView/Viewer/Card Docked Viewer.prefab
@@ -495,7 +495,6 @@ MonoBehaviour:
   - {fileID: 7603630240227926939}
   - {fileID: 8529563614461424557}
   - {fileID: 7126045294037836214}
-  - {fileID: 5436329676496674114}
   cardImages:
   - {fileID: 9117401374665988874}
   - {fileID: 1521908834704067835}
@@ -1775,7 +1774,6 @@ GameObject:
   - component: {fileID: 5788882388657207090}
   - component: {fileID: 6365138097289247228}
   - component: {fileID: 4819511972905837331}
-  - component: {fileID: 5436329676496674114}
   m_Layer: 5
   m_Name: Card Image
   m_TagString: Untagged
@@ -1800,7 +1798,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -1147.8, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6365138097289247228
 CanvasRenderer:
@@ -1831,7 +1829,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: 21300000, guid: 062b85b23e1058941a28497c2519e749, type: 3}
-  m_Type: 1
+  m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1
   m_FillMethod: 4
@@ -1840,20 +1838,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &5436329676496674114
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6751573758440649778}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_AspectMode: 3
-  m_AspectRatio: 0.715
 --- !u!1 &6847711490298176221
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/CardGameView/Viewer/Card Viewer.prefab
+++ b/Assets/Prefabs/CardGameView/Viewer/Card Viewer.prefab
@@ -219,7 +219,6 @@ MonoBehaviour:
   - {fileID: 7087516293771782191}
   - {fileID: 4258690190980776080}
   - {fileID: 114671952942199310}
-  - {fileID: 114564663078920856}
   cardImages:
   - {fileID: 3197973267056799822}
   - {fileID: 6286194478411323335}
@@ -1203,7 +1202,6 @@ GameObject:
   - component: {fileID: 224126359258657348}
   - component: {fileID: 222352745273761712}
   - component: {fileID: 114442512476595824}
-  - component: {fileID: 114564663078920856}
   m_Layer: 5
   m_Name: Card Image
   m_TagString: Untagged
@@ -1228,7 +1226,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -1147.8, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &222352745273761712
 CanvasRenderer:
@@ -1259,7 +1257,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: 21300000, guid: 062b85b23e1058941a28497c2519e749, type: 3}
-  m_Type: 1
+  m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1
   m_FillMethod: 4
@@ -1268,20 +1266,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &114564663078920856
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1769158807627662}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_AspectMode: 3
-  m_AspectRatio: 0.715
 --- !u!1 &1833269177060474
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardModel.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardModel.cs
@@ -260,6 +260,8 @@ namespace Cgs.CardGameView.Multiplayer
                 Value.RegisterDisplay(this);
         }
 
+        public bool UsesOrientedImage => true;
+
         public void SetImageSprite(Sprite imageSprite)
         {
             if (imageSprite == null)

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardStack.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardStack.cs
@@ -301,6 +301,8 @@ namespace Cgs.CardGameView.Multiplayer
                 RequestDelete();
         }
 
+        public bool UsesOrientedImage => true;
+
         public void SetImageSprite(Sprite imageSprite)
         {
             if (imageSprite == null)

--- a/Assets/Scripts/Cgs/CardGameView/Viewer/CardViewer.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Viewer/CardViewer.cs
@@ -460,6 +460,9 @@ namespace Cgs.CardGameView.Viewer
             SelectedPropertyIndex++;
         }
 
+        // The preview and zoom show the card image as it is, without rotating it to the game's card orientation
+        public bool UsesOrientedImage => false;
+
         public void SetImageSprite(Sprite imageSprite)
         {
             foreach (var cardImage in cardImages.Where(cardImage => cardImage != null))

--- a/Assets/Scripts/FinolDigital.Cgs.Json.Unity/ICardDisplay.cs
+++ b/Assets/Scripts/FinolDigital.Cgs.Json.Unity/ICardDisplay.cs
@@ -8,6 +8,10 @@ namespace FinolDigital.Cgs.Json.Unity
 {
     public interface ICardDisplay
     {
+        // Displays that size themselves to the game's card size should use the oriented image,
+        // while displays that fit the image itself, like the card viewer, should not
+        bool UsesOrientedImage { get; }
+
         void SetImageSprite(Sprite imageSprite);
     }
 }

--- a/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCard.cs
+++ b/Assets/Scripts/FinolDigital.Cgs.Json.Unity/UnityCard.cs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityExtensionMethods;
@@ -42,6 +43,14 @@ namespace FinolDigital.Cgs.Json.Unity
             get => _imageSprite;
             set
             {
+                if (_orientedImageSprite != null && _orientedImageSprite != _imageSprite)
+                {
+                    Object.Destroy(_orientedImageSprite.texture);
+                    Object.Destroy(_orientedImageSprite);
+                }
+
+                _orientedImageSprite = null;
+
                 if (_imageSprite != null)
                 {
                     Object.Destroy(_imageSprite.texture);
@@ -50,11 +59,25 @@ namespace FinolDigital.Cgs.Json.Unity
 
                 _imageSprite = value;
                 foreach (var cardDisplay in DisplaysUsingImage)
-                    cardDisplay.SetImageSprite(_imageSprite);
+                    cardDisplay.SetImageSprite(GetImageSpriteFor(cardDisplay));
             }
         }
 
         private Sprite _imageSprite;
+
+        // Card images with a different orientation than the game's card size (eg a horizontal scan for a
+        // vertical card) would get stretched to fit, so this variant is rotated to match the card's orientation
+        public Sprite OrientedImageSprite
+        {
+            get
+            {
+                if (_orientedImageSprite == null)
+                    _orientedImageSprite = CreateOrientedImageSprite();
+                return _orientedImageSprite;
+            }
+        }
+
+        private Sprite _orientedImageSprite;
 
         public bool IsLoadingImage { get; private set; }
 
@@ -73,9 +96,14 @@ namespace FinolDigital.Cgs.Json.Unity
         {
             DisplaysUsingImage.Add(cardDisplay);
             if (ImageSprite != null)
-                cardDisplay.SetImageSprite(ImageSprite);
+                cardDisplay.SetImageSprite(GetImageSpriteFor(cardDisplay));
             else if (!IsLoadingImage)
                 EnqueueImageLoad();
+        }
+
+        private Sprite GetImageSpriteFor(ICardDisplay cardDisplay)
+        {
+            return cardDisplay.UsesOrientedImage ? OrientedImageSprite : ImageSprite;
         }
 
         private void EnqueueImageLoad()
@@ -89,6 +117,35 @@ namespace FinolDigital.Cgs.Json.Unity
             if (imageSprite != null)
                 ImageSprite = imageSprite;
             IsLoadingImage = false;
+        }
+
+        // Returns ImageSprite itself when its orientation already matches the game's card size
+        private Sprite CreateOrientedImageSprite()
+        {
+            if (_imageSprite == null || SourceGame == null)
+                return _imageSprite;
+
+            var texture = _imageSprite.texture;
+            var cardSize = SourceGame.CardSize;
+            var isImageLandscape = texture.width > texture.height;
+            var isImagePortrait = texture.width < texture.height;
+            var isCardLandscape = Mathf.Abs(cardSize.X) > Mathf.Abs(cardSize.Y);
+            var isCardPortrait = Mathf.Abs(cardSize.X) < Mathf.Abs(cardSize.Y);
+            if (!(isImageLandscape && isCardPortrait) && !(isImagePortrait && isCardLandscape))
+                return _imageSprite;
+
+            // Rotate clockwise, so that rotating the card counter-clockwise in-game reads the image upright
+            try
+            {
+                var rotatedTexture = UnityFileMethods.Rotate90Clockwise(texture);
+                return Sprite.Create(rotatedTexture, new Rect(0, 0, rotatedTexture.width, rotatedTexture.height),
+                    new Vector2(0.5f, 0.5f));
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"Failed to rotate image for card: {Name} ({Id}): {e}");
+                return _imageSprite;
+            }
         }
 
         public void UnregisterDisplay(ICardDisplay cardDisplay)

--- a/Assets/Scripts/UnityExtensionMethods/UnityFileMethods.cs
+++ b/Assets/Scripts/UnityExtensionMethods/UnityFileMethods.cs
@@ -570,5 +570,27 @@ namespace UnityExtensionMethods
             Debug.LogWarning("CreateSprite::TextureNull");
             return null;
         }
+
+        // Requires a readable texture; the caller is responsible for destroying the original texture
+        public static Texture2D Rotate90Clockwise(Texture2D texture)
+        {
+            var width = texture.width;
+            var height = texture.height;
+            var rotatedWidth = height;
+            var rotatedHeight = width;
+            var pixels = texture.GetPixels32();
+            var rotatedPixels = new Color32[pixels.Length];
+            for (var y = 0; y < height; y++)
+            {
+                var row = y * width;
+                for (var x = 0; x < width; x++)
+                    rotatedPixels[(width - 1 - x) * rotatedWidth + y] = pixels[row + x];
+            }
+
+            var rotatedTexture = new Texture2D(rotatedWidth, rotatedHeight, TextureFormat.RGBA32, false);
+            rotatedTexture.SetPixels32(rotatedPixels);
+            rotatedTexture.Apply();
+            return rotatedTexture;
+        }
     }
 }

--- a/Assets/Tests/PlayMode/ImageOrientationTests.cs
+++ b/Assets/Tests/PlayMode/ImageOrientationTests.cs
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+using System;
+using System.Collections.Generic;
+using FinolDigital.Cgs.Json;
+using FinolDigital.Cgs.Json.Unity;
+using NUnit.Framework;
+using UnityEngine;
+using UnityExtensionMethods;
+
+namespace Tests.PlayMode
+{
+    public class ImageOrientationTests
+    {
+        private static UnityCard CreateCardWithImage(Float2 cardSize, int imageWidth, int imageHeight)
+        {
+            var game = new UnityCardGame(null, "orientation_test_" + Guid.NewGuid())
+            {
+                CardProperties = new List<PropertyDef>(), CardSize = cardSize
+            };
+            var card = new UnityCard(game, "orientation_card", "Orientation Card", Set.DefaultCode,
+                new Dictionary<string, PropertyDefValuePair>(), false);
+            var texture = new Texture2D(imageWidth, imageHeight, TextureFormat.RGBA32, false);
+            texture.Apply();
+            card.ImageSprite = Sprite.Create(texture, new Rect(0, 0, imageWidth, imageHeight), new Vector2(0.5f, 0.5f));
+            return card;
+        }
+
+        [Test]
+        public void OrientedImageSprite_RotatesLandscapeImageForPortraitCard()
+        {
+            var card = CreateCardWithImage(new Float2(2.5f, 3.5f), 4, 2);
+
+            // The unrotated image is preserved for displays that show the image as-is, like the card viewer
+            Assert.AreEqual(4, card.ImageSprite.texture.width);
+            Assert.AreEqual(2, card.ImageSprite.texture.height);
+
+            Assert.AreNotSame(card.ImageSprite, card.OrientedImageSprite);
+            Assert.AreEqual(2, card.OrientedImageSprite.texture.width);
+            Assert.AreEqual(4, card.OrientedImageSprite.texture.height);
+
+            card.ImageSprite = null;
+        }
+
+        [Test]
+        public void OrientedImageSprite_ReusesImageWhenOrientationAlreadyMatches()
+        {
+            var card = CreateCardWithImage(new Float2(2.5f, 3.5f), 2, 4);
+
+            Assert.AreSame(card.ImageSprite, card.OrientedImageSprite);
+
+            card.ImageSprite = null;
+        }
+
+        [Test]
+        public void OrientedImageSprite_RotatesPortraitImageForLandscapeCard()
+        {
+            var card = CreateCardWithImage(new Float2(3.5f, 2.5f), 2, 4);
+
+            Assert.AreNotSame(card.ImageSprite, card.OrientedImageSprite);
+            Assert.AreEqual(4, card.OrientedImageSprite.texture.width);
+            Assert.AreEqual(2, card.OrientedImageSprite.texture.height);
+
+            card.ImageSprite = null;
+        }
+
+        [Test]
+        public void Rotate90Clockwise_SwapsDimensionsAndMapsPixels()
+        {
+            var texture = new Texture2D(3, 2, TextureFormat.RGBA32, false);
+            var bottomLeft = new Color32(255, 0, 0, 255);
+            var topLeft = new Color32(0, 255, 0, 255);
+            var topRight = new Color32(0, 0, 255, 255);
+            var pixels = new Color32[6];
+            for (var i = 0; i < pixels.Length; i++)
+                pixels[i] = new Color32(255, 255, 255, 255);
+            pixels[0] = bottomLeft; // (0, 0)
+            pixels[3] = topLeft; // (0, 1)
+            pixels[5] = topRight; // (2, 1)
+            texture.SetPixels32(pixels);
+            texture.Apply();
+
+            var rotatedTexture = UnityFileMethods.Rotate90Clockwise(texture);
+
+            Assert.AreEqual(2, rotatedTexture.width);
+            Assert.AreEqual(3, rotatedTexture.height);
+            // Rotating clockwise moves the left edge to the top and the top edge to the right
+            Assert.AreEqual(bottomLeft, (Color32)rotatedTexture.GetPixel(0, 2));
+            Assert.AreEqual(topLeft, (Color32)rotatedTexture.GetPixel(1, 2));
+            Assert.AreEqual(topRight, (Color32)rotatedTexture.GetPixel(1, 0));
+
+            UnityEngine.Object.Destroy(texture);
+            UnityEngine.Object.Destroy(rotatedTexture);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/ImageOrientationTests.cs.meta
+++ b/Assets/Tests/PlayMode/ImageOrientationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a65a5eafcc53497bb3333c51d86ba7b8


### PR DESCRIPTION
## What's Changed
- Cards whose images are sideways compared to the rest of the game, like the horizontal cards in Arkham Horror, are now shown the right way around instead of being squished to fit
- The card preview and zoom now show card images at their true shape, without stretching