### PR TITLE
Fix stacking, shuffling, and zone capture in offline play

### DIFF
--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardModel.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardModel.cs
@@ -377,6 +377,11 @@ namespace Cgs.CardGameView.Multiplayer
             if (cardModel == this || (_placeHolder != null && cardModel == _placeHolder.GetComponent<CardModel>()))
                 return;
 
+            // The event system and PostDragPlayable can both deliver the same drop,
+            // so a card that has already been stacked must not be stacked again
+            if (ToDelete || cardModel.ToDelete)
+                return;
+
             Debug.Log($"Dropped {cardModel.gameObject.name} on {gameObject.name}");
 
             if (!PlaySettings.AutoStackCards)
@@ -393,7 +398,7 @@ namespace Cgs.CardGameView.Multiplayer
             }
 
             var cards = new List<UnityCard> { Value, cardModel.Value };
-            if (IsSpawned)
+            if (CgsNetManager.Instance.IsOnline && CgsNetManager.Instance.LocalPlayer != null)
                 CgsNetManager.Instance.LocalPlayer.RequestNewCardStack(PlayController.DefaultStackName, cards,
                     Position, Rotation, !IsFacedown);
             else
@@ -407,6 +412,9 @@ namespace Cgs.CardGameView.Multiplayer
 
         public void OnDrop(CardStack cardStack)
         {
+            if (ToDelete || cardStack.ToDelete)
+                return;
+
             cardStack.RequestInsert(0, Id);
             RequestDelete();
         }
@@ -554,7 +562,9 @@ namespace Cgs.CardGameView.Multiplayer
 
             var gridPosition = CalculateGridPosition();
 
-            if (PlaySettings.AutoStackCards && PlayController.Instance != null)
+            // Grid positions are local to the play area, so only cards in the play area can be compared to siblings
+            if (PlaySettings.AutoStackCards && PlayController.Instance != null &&
+                PlayController.Instance.playAreaCardZone.transform == transform.parent)
             {
                 var playAreaCardZoneTransform = PlayController.Instance.playAreaCardZone.transform;
                 for (var i = 0; i < playAreaCardZoneTransform.childCount; i++)
@@ -563,7 +573,7 @@ namespace Cgs.CardGameView.Multiplayer
                     if (siblingTransform == transform)
                         continue;
 
-                    var distance = Vector2.Distance(siblingTransform.position, gridPosition);
+                    var distance = Vector2.Distance(siblingTransform.localPosition, gridPosition);
                     if (distance > 0.1f)
                         continue;
 
@@ -571,7 +581,8 @@ namespace Cgs.CardGameView.Multiplayer
                     if (siblingCardModel != null)
                     {
                         var cards = new List<UnityCard> { siblingCardModel.Value, Value };
-                        if (IsSpawned)
+                        if (CgsNetManager.Instance != null && CgsNetManager.Instance.IsOnline &&
+                            CgsNetManager.Instance.LocalPlayer != null)
                             CgsNetManager.Instance.LocalPlayer.RequestNewCardStack(PlayController.DefaultStackName,
                                 cards, siblingCardModel.Position, siblingCardModel.Rotation,
                                 !siblingCardModel.IsFacedown);
@@ -781,14 +792,17 @@ namespace Cgs.CardGameView.Multiplayer
             cachedTransform.SetParent(PlaceHolder.parent);
             cachedTransform.SetSiblingIndex(PlaceHolder.GetSiblingIndex());
             cachedTransform.localScale = Vector3.one;
+
+            // The move is over before the zones are notified, since their add behaviors,
+            // like capture into an overlapping card zone, may start a new move
+            PlaceHolderCardZone = null;
+            Visibility.blocksRaycasts = true;
+            IsMovingToPlaceHolder = false;
+
             if (previousParentCardZone != null)
                 previousParentCardZone.OnRemove(this);
             if (ParentCardZone != null)
                 ParentCardZone.OnAdd(this);
-
-            PlaceHolderCardZone = null;
-            Visibility.blocksRaycasts = true;
-            IsMovingToPlaceHolder = false;
         }
 
         private void ParentToCanvas(Vector3 targetPosition)

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardStack.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardStack.cs
@@ -78,6 +78,12 @@ namespace Cgs.CardGameView.Multiplayer
 
         protected override bool IsAdditionalClientAuthorized(ulong clientId) => true;
 
+        // Offline (single-player) stacks keep all of their state locally, since there is nothing to sync
+        private static bool IsOnline => CgsNetManager.Instance != null && CgsNetManager.Instance.IsOnline;
+
+        // Only a spawned stack can be referenced on the server; any other stack is acted on locally
+        private bool CanRequestFromServer => IsSpawned && IsOnline && CgsNetManager.Instance.LocalPlayer != null;
+
         public GameObject stackViewerPrefab;
         public GameObject cardModelPrefab;
 
@@ -110,7 +116,7 @@ namespace Cgs.CardGameView.Multiplayer
         {
             get
             {
-                if (CgsNetManager.Instance == null || !CgsNetManager.Instance.IsOnline)
+                if (!IsOnline)
                     return _cards;
 
                 _cards = new List<UnityCard>();
@@ -124,7 +130,7 @@ namespace Cgs.CardGameView.Multiplayer
                 foreach (var unityCard in value)
                     _cards.Add(unityCard);
 
-                if (!CgsNetManager.Instance.IsOnline)
+                if (!IsOnline)
                     return;
 
                 if (!CgsNetManager.Instance.IsConnectedClient || IsOwner)
@@ -296,8 +302,7 @@ namespace Cgs.CardGameView.Multiplayer
                 TopCard?.RegisterDisplay(this);
 
             // Empty stacks should not persist, but only the authority can delete them
-            if (Cards.Count == 0 &&
-                (CgsNetManager.Instance == null || !CgsNetManager.Instance.IsOnline || IsServer))
+            if (Cards.Count == 0 && (!IsOnline || IsServer))
                 RequestDelete();
         }
 
@@ -328,7 +333,7 @@ namespace Cgs.CardGameView.Multiplayer
                 actionLabel.text = _actionText.Value;
             }
 
-            if (isAction && (!CgsNetManager.Instance.IsConnectedClient || IsServer))
+            if (isAction && (!IsOnline || !CgsNetManager.Instance.IsConnectedClient || IsServer))
                 _actionTime.Value -= Time.deltaTime;
 
             if (HoldTime > DragHoldTime)
@@ -402,7 +407,7 @@ namespace Cgs.CardGameView.Multiplayer
                 IsDeckShared, PlayController.Instance.playAreaCardZone);
             RemovePointer(eventData);
 
-            if (CgsNetManager.Instance.IsOnline)
+            if (CanRequestFromServer)
                 CgsNetManager.Instance.LocalPlayer.RequestRemoveAt(gameObject, cards.Count - 1);
             else
                 OwnerPopCard();
@@ -481,6 +486,11 @@ namespace Cgs.CardGameView.Multiplayer
 
         public void OnDrop(CardModel cardModel)
         {
+            // The event system and PostDragPlayable can both deliver the same drop,
+            // so a card that has already been added to a stack must not be added again
+            if (ToDelete || cardModel.ToDelete)
+                return;
+
             cardModel.PlaceHolderCardZone = null;
             RequestInsert(Cards.Count, cardModel.Id);
             cardModel.RequestDelete();
@@ -488,6 +498,9 @@ namespace Cgs.CardGameView.Multiplayer
 
         public void OnDrop(CardStack cardStack)
         {
+            if (ToDelete || cardStack.ToDelete)
+                return;
+
             var cards = Cards;
             for (var i = cards.Count - 1; i >= 0; i--)
                 cardStack.RequestInsert(0, cards[i].Id);
@@ -501,7 +514,7 @@ namespace Cgs.CardGameView.Multiplayer
 
         public void RequestInsert(int index, string cardId)
         {
-            if (LacksOwnership || (CgsNetManager.Instance.IsOnline && !IsServer))
+            if ((LacksOwnership || !IsServer) && CanRequestFromServer)
                 CgsNetManager.Instance.LocalPlayer.RequestInsert(gameObject, index, cardId);
             else
                 OwnerInsert(index, cardId);
@@ -511,7 +524,7 @@ namespace Cgs.CardGameView.Multiplayer
         {
             Debug.Log($"CardStack: {name} insert {cardId} at {index} of {Cards.Count}");
             _cards.Insert(index, LookupCard(cardId));
-            if (CgsNetManager.Instance.IsOnline)
+            if (IsOnline)
                 _cardIds.Insert(index, cardId);
             else
                 SyncView();
@@ -519,7 +532,7 @@ namespace Cgs.CardGameView.Multiplayer
 
         public void RequestRemoveAt(int index)
         {
-            if (LacksOwnership)
+            if (LacksOwnership && CanRequestFromServer)
                 CgsNetManager.Instance.LocalPlayer.RequestRemoveAt(gameObject, index);
             else
                 OwnerRemoveAt(index);
@@ -531,7 +544,7 @@ namespace Cgs.CardGameView.Multiplayer
                 return UnityCard.Blank.Id;
             var cardId = _cards[index].Id;
             _cards.RemoveAt(index);
-            if (CgsNetManager.Instance.IsOnline)
+            if (IsOnline)
                 _cardIds.RemoveAt(index);
             else
                 SyncView();
@@ -587,7 +600,7 @@ namespace Cgs.CardGameView.Multiplayer
 
         private void Shuffle()
         {
-            if (CgsNetManager.Instance.IsOnline)
+            if (CanRequestFromServer)
                 CgsNetManager.Instance.LocalPlayer.RequestShuffle(gameObject);
             else
                 DoShuffle();
@@ -595,23 +608,37 @@ namespace Cgs.CardGameView.Multiplayer
 
         public void DoShuffle()
         {
-            var cards = Cards.Select(card => card.Id).ToList();
-            cards.Shuffle();
-
-            _cards = cards.Select(LookupCard).ToList();
-
-            if (!CgsNetManager.Instance.IsOnline)
-                return;
-
-            if (CgsNetManager.Instance.IsConnectedClient && !IsServer)
+            if (IsSpawned && !IsServer)
             {
                 Debug.LogError("Attempted to shuffle on client!");
                 return;
             }
 
-            _cardIds.Clear();
-            foreach (var card in cards)
-                _cardIds.Add(card);
+            var cards = Cards.Select(card => card.Id).ToList();
+            cards.Shuffle();
+
+            var previousTopCard = TopCard;
+            _cards = cards.Select(LookupCard).ToList();
+
+            if (IsOnline)
+            {
+                // Syncing the card ids updates every client's view of this stack
+                _cardIds.Clear();
+                foreach (var card in cards)
+                    _cardIds.Add(card);
+            }
+            else
+            {
+                // Offline stacks have no card ids to sync, so the shuffled result is applied here
+                var topCardValue = TopCard;
+                if (IsTopFaceup && previousTopCard != topCardValue)
+                {
+                    previousTopCard?.UnregisterDisplay(this);
+                    topCardValue?.RegisterDisplay(this);
+                }
+
+                SyncView();
+            }
 
             _actionText.Value = ShuffleText;
             _actionTime.Value = 1;

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardStack.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardStack.cs
@@ -532,7 +532,7 @@ namespace Cgs.CardGameView.Multiplayer
 
         public void RequestRemoveAt(int index)
         {
-            if (LacksOwnership && CanRequestFromServer)
+            if (!IsServer && CanRequestFromServer)
                 CgsNetManager.Instance.LocalPlayer.RequestRemoveAt(gameObject, index);
             else
                 OwnerRemoveAt(index);

--- a/Assets/Scripts/Cgs/Play/Multiplayer/CgsNetPlayer.cs
+++ b/Assets/Scripts/Cgs/Play/Multiplayer/CgsNetPlayer.cs
@@ -722,6 +722,10 @@ namespace Cgs.Play.Multiplayer
                 ? cardModelTransform.GetSiblingIndex()
                 : -1;
             cardModel.SnapToGrid();
+            // Snapping may auto-stack this card into an overlapping card or stack, which consumes it
+            if (cardModel.ToDelete)
+                return;
+
             var position = ((RectTransform) cardModelTransform).localPosition;
             var rotation = cardModelTransform.localRotation;
             var isFacedown = cardModel.IsFacedown && !cardModel.Value.IsBackFaceCard;


### PR DESCRIPTION
## What's Changed
- Shuffling a stack in offline (single-player) games now actually shows its result, including the "Shuffled!" message
- Dropping a card onto another card in the play area now creates a new stack instead of doing nothing
- Dropping a card onto a card or stack no longer duplicates it
- Cards left on top of a card zone in the play area now get added into that zone