### PR TITLE
Play Help Menu key fixes and card sorting shortcut

### DIFF
--- a/Assets/InputSystem_Actions.inputactions
+++ b/Assets/InputSystem_Actions.inputactions
@@ -982,6 +982,15 @@
             "id": "9483d542-2816-4213-9c7e-74c404bbe456",
             "actions": [
                 {
+                    "name": "GamesManagementMenu",
+                    "type": "Button",
+                    "id": "c75eebc9-8bd9-40da-85d8-50990061a015",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
                     "name": "New",
                     "type": "Button",
                     "id": "bca32cfe-5dda-4ab5-9721-4c6e7c48dd41",
@@ -1000,9 +1009,9 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "GamesManagementMenu",
+                    "name": "Sort",
                     "type": "Button",
-                    "id": "c75eebc9-8bd9-40da-85d8-50990061a015",
+                    "id": "3eb40ad8-783c-4b83-9ffc-f04e6feb8c7a",
                     "expectedControlType": "",
                     "processors": "",
                     "interactions": "",
@@ -1138,8 +1147,19 @@
                 },
                 {
                     "name": "",
-                    "id": "123ada3d-56df-4526-88da-d1a44402eab5",
+                    "id": "92fcbaf4-688c-426f-a5a7-69c32a3a9909",
                     "path": "<Gamepad>/leftShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "GamesManagementMenu",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "5b96f43c-22e6-4a06-b2e6-d1afc14aebc3",
+                    "path": "<Gamepad>/start",
                     "interactions": "",
                     "processors": "",
                     "groups": ";Gamepad",
@@ -1166,6 +1186,17 @@
                     "processors": "",
                     "groups": ";Keyboard&Mouse",
                     "action": "GamesManagementMenu",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "a96e4d84-a367-4fdd-a94a-14cae1aecbc3",
+                    "path": "<Gamepad>/rightStickPress",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Sort",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },

--- a/Assets/Prefabs/CardGameView/Multiplayer/Card Stack.prefab
+++ b/Assets/Prefabs/CardGameView/Multiplayer/Card Stack.prefab
@@ -38,9 +38,9 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 3318835810156797752}
   - {fileID: 4071995927961036205}
   - {fileID: 3318835810310926618}
+  - {fileID: 3318835810156797752}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -150,7 +150,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 3701492064
+  GlobalObjectIdHash: 3001253089
   InScenePlacedSourceGlobalObjectIdHash: 0
   DeferredDespawnTick: 0
   Ownership: 1
@@ -289,7 +289,7 @@ PrefabInstance:
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
@@ -299,12 +299,12 @@ PrefabInstance:
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: -10
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
@@ -349,12 +349,12 @@ PrefabInstance:
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -60
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
@@ -379,7 +379,7 @@ PrefabInstance:
     - target: {fileID: 6960506880217691888, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_FontData.m_Alignment
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 7755028453825778640, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
@@ -591,7 +591,7 @@ PrefabInstance:
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
@@ -601,7 +601,7 @@ PrefabInstance:
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
@@ -656,7 +656,7 @@ PrefabInstance:
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 60
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}

--- a/Assets/Prefabs/CardGameView/Multiplayer/DiceZone.prefab
+++ b/Assets/Prefabs/CardGameView/Multiplayer/DiceZone.prefab
@@ -34,8 +34,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 8802011591189785648}
   - {fileID: 2259648436058499177}
+  - {fileID: 8802011591189785648}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -93,7 +93,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 3550046621
+  GlobalObjectIdHash: 1610098201
   InScenePlacedSourceGlobalObjectIdHash: 0
   DeferredDespawnTick: 0
   Ownership: 1
@@ -215,27 +215,27 @@ PrefabInstance:
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
-        type: 3}
-      propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
       propertyPath: m_SizeDelta.x
-      value: 100
+      value: -10
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
@@ -280,12 +280,12 @@ PrefabInstance:
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -60
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1636166841839465175, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
@@ -306,6 +306,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Text
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6960506880217691888, guid: eb9a84c1b0b6d25479b907acb118cde9,
+        type: 3}
+      propertyPath: m_FontData.m_Alignment
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 7755028453825778640, guid: eb9a84c1b0b6d25479b907acb118cde9,
         type: 3}
@@ -401,7 +406,7 @@ PrefabInstance:
     - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
         type: 3}
@@ -411,7 +416,7 @@ PrefabInstance:
     - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
         type: 3}
@@ -466,7 +471,7 @@ PrefabInstance:
     - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 85
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
         type: 3}

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardZone.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardZone.cs
@@ -215,12 +215,13 @@ namespace Cgs.CardGameView.Multiplayer
             // The label is not a card, so the layout group and the card raycasts must both ignore it
             countLabelGameObject.GetOrAddComponent<LayoutElement>().ignoreLayout = true;
             var countLabelRectTransform = (RectTransform)countLabelGameObject.transform;
-            countLabelRectTransform.anchorMin = new Vector2(0.5f, 0);
-            countLabelRectTransform.anchorMax = new Vector2(0.5f, 0);
-            countLabelRectTransform.pivot = new Vector2(0.5f, 0);
-            countLabelRectTransform.anchoredPosition = new Vector2(0, -60);
+            countLabelRectTransform.anchorMin = Vector2.one;
+            countLabelRectTransform.anchorMax = Vector2.one;
+            countLabelRectTransform.pivot = new Vector2(1, 0);
+            countLabelRectTransform.anchoredPosition = new Vector2(-10, 0);
             countLabelRectTransform.sizeDelta = new Vector2(100, 60);
             _countLabel = countLabelGameObject.GetComponent<Text>();
+            _countLabel.alignment = TextAnchor.MiddleRight;
             _countLabel.raycastTarget = false;
             _countLabel.text = "0";
         }

--- a/Assets/Scripts/Cgs/Cards/CardsExplorer.cs
+++ b/Assets/Scripts/Cgs/Cards/CardsExplorer.cs
@@ -65,8 +65,9 @@ namespace Cgs.Cards
             CardGameManager.Instance.OnSceneActions.Add(ResetBannerCardsAndButtons);
 
             InputSystem.actions.FindAction(Tags.SubMenuFocusNext).performed += InputFocus;
+            InputSystem.actions.FindAction(Tags.CardsSort).performed += InputGamesManagementMenu;
             InputSystem.actions.FindAction(Tags.CardsFilter).performed += InputCardsFilter;
-            InputSystem.actions.FindAction(Tags.CardsGameManagementMenu).performed += InputGamesManagementMenu;
+            InputSystem.actions.FindAction(Tags.CardsGamesManagementMenu).performed += InputGamesManagementMenu;
             InputSystem.actions.FindAction(Tags.CardsNew).performed += InputNewCard;
             InputSystem.actions.FindAction(Tags.CardsEdit).performed += InputEditCard;
             InputSystem.actions.FindAction(Tags.PlayerCancel).performed += InputCancel;
@@ -195,8 +196,9 @@ namespace Cgs.Cards
         private void OnDisable()
         {
             InputSystem.actions.FindAction(Tags.SubMenuFocusNext).performed -= InputFocus;
+            InputSystem.actions.FindAction(Tags.CardsSort).performed -= InputGamesManagementMenu;
             InputSystem.actions.FindAction(Tags.CardsFilter).performed -= InputCardsFilter;
-            InputSystem.actions.FindAction(Tags.CardsGameManagementMenu).performed -= InputGamesManagementMenu;
+            InputSystem.actions.FindAction(Tags.CardsGamesManagementMenu).performed -= InputGamesManagementMenu;
             InputSystem.actions.FindAction(Tags.CardsNew).performed -= InputNewCard;
             InputSystem.actions.FindAction(Tags.CardsEdit).performed -= InputEditCard;
             InputSystem.actions.FindAction(Tags.PlayerCancel).performed -= InputCancel;

--- a/Assets/Scripts/Cgs/Decks/DeckEditor.cs
+++ b/Assets/Scripts/Cgs/Decks/DeckEditor.cs
@@ -131,9 +131,7 @@ namespace Cgs.Decks
                                   CardGameManager.Instance.ModalCanvas != null || searchResults.inputField.isFocused;
 
         // false: horizontal card zones with a vertical scrollbar; true: vertical card zones with a horizontal scrollbar
-        public bool IsHorizontalLayout => _isHorizontalLayout;
-
-        private bool _isHorizontalLayout;
+        public bool IsHorizontalLayout { get; private set; }
 
         private void OnEnable()
         {
@@ -145,8 +143,9 @@ namespace Cgs.Decks
             InputSystem.actions.FindAction(Tags.DecksLoad).performed += InputLoad;
             InputSystem.actions.FindAction(Tags.DecksSave).performed += InputSave;
             InputSystem.actions.FindAction(Tags.DecksPivot).performed += InputPivot;
-            InputSystem.actions.FindAction(Tags.SubMenuFocusNext).performed += InputFocus;
+            InputSystem.actions.FindAction(Tags.CardsSort).performed += InputPivot;
             InputSystem.actions.FindAction(Tags.CardsFilter).performed += InputFilter;
+            InputSystem.actions.FindAction(Tags.SubMenuFocusNext).performed += InputFocus;
             InputSystem.actions.FindAction(Tags.PlayerCancel).performed += InputCancel;
         }
 
@@ -179,7 +178,7 @@ namespace Cgs.Decks
 
         private void Consolidate()
         {
-            if (_isHorizontalLayout)
+            if (IsHorizontalLayout)
                 ConsolidateVertical();
             else
                 ConsolidateHorizontal();
@@ -346,10 +345,10 @@ namespace Cgs.Decks
 
         private void AddCard(UnityCard card)
         {
-            if (card == null)
+            if (card == null || CardZones.Count <= 0)
                 return;
 
-            var cardZone = CardZones.Last();
+            var cardZone = CardZones[^1];
             var cardModel = Instantiate(cardModelPrefab, cardZone.transform).GetOrAddComponent<CardModel>();
             cardModel.Value = card;
 
@@ -396,7 +395,7 @@ namespace Cgs.Decks
             if (cardZoneIndex < 0 || cardZoneIndex >= CardZones.Count)
                 return;
 
-            if (_isHorizontalLayout)
+            if (IsHorizontalLayout)
                 scrollRect.horizontalNormalizedPosition = CardZones.Count > 1
                     ? cardZoneIndex / (CardZones.Count - 1f)
                     : 0f;
@@ -470,7 +469,7 @@ namespace Cgs.Decks
                 AddCard((UnityCard)card);
             SavedDeck = deck;
             UpdateDeckStats();
-            if (_isHorizontalLayout)
+            if (IsHorizontalLayout)
                 scrollRect.horizontalNormalizedPosition = 0;
             else
                 scrollRect.verticalNormalizedPosition = 1;
@@ -509,7 +508,7 @@ namespace Cgs.Decks
         [UsedImplicitly]
         public void Pivot()
         {
-            _isHorizontalLayout = !_isHorizontalLayout;
+            IsHorizontalLayout = !IsHorizontalLayout;
             ApplyLayout();
         }
 
@@ -521,17 +520,17 @@ namespace Cgs.Decks
                 Destroy(cardZone.gameObject);
             CardZones.Clear();
 
-            scrollRect.horizontal = _isHorizontalLayout;
-            scrollRect.vertical = !_isHorizontalLayout;
+            scrollRect.horizontal = IsHorizontalLayout;
+            scrollRect.vertical = !IsHorizontalLayout;
             if (scrollRect.horizontalScrollbar != null)
-                scrollRect.horizontalScrollbar.gameObject.SetActive(_isHorizontalLayout);
+                scrollRect.horizontalScrollbar.gameObject.SetActive(IsHorizontalLayout);
             if (scrollRect.verticalScrollbar != null)
-                scrollRect.verticalScrollbar.gameObject.SetActive(!_isHorizontalLayout);
+                scrollRect.verticalScrollbar.gameObject.SetActive(!IsHorizontalLayout);
 
             foreach (var verticalScrollArea in verticalScrollAreas)
-                verticalScrollArea.SetActive(!_isHorizontalLayout);
+                verticalScrollArea.SetActive(!IsHorizontalLayout);
             foreach (var horizontalScrollArea in horizontalScrollAreas)
-                horizontalScrollArea.SetActive(_isHorizontalLayout);
+                horizontalScrollArea.SetActive(IsHorizontalLayout);
 
             var layoutGroup = layoutContent.GetComponent<HorizontalOrVerticalLayoutGroup>();
             if (layoutGroup != null)
@@ -541,7 +540,7 @@ namespace Cgs.Decks
                 DestroyImmediate(layoutGroup);
             }
 
-            if (_isHorizontalLayout)
+            if (IsHorizontalLayout)
             {
                 layoutContent.anchorMin = Vector2.zero;
                 layoutContent.anchorMax = Vector2.up;
@@ -573,7 +572,7 @@ namespace Cgs.Decks
 
             // Rebuild card models directly and consolidate once at the end, rather than
             // going through AddCard, which consolidates per-card and would be O(n^2)
-            var cardZoneTransform = CardZones.Last().transform;
+            var cardZoneTransform = CardZones[^1].transform;
             foreach (var card in cards)
             {
                 var cardModel = Instantiate(cardModelPrefab, cardZoneTransform).GetOrAddComponent<CardModel>();
@@ -585,18 +584,10 @@ namespace Cgs.Decks
             Consolidate();
             UpdateDeckStats();
 
-            if (_isHorizontalLayout)
+            if (IsHorizontalLayout)
                 scrollRect.horizontalNormalizedPosition = 0;
             else
                 scrollRect.verticalNormalizedPosition = 1;
-        }
-
-        private void InputFocus(InputAction.CallbackContext callbackContext)
-        {
-            if (IsBlocked)
-                return;
-
-            searchResults.inputField.ActivateInputField();
         }
 
         private void InputFilter(InputAction.CallbackContext callbackContext)
@@ -605,6 +596,14 @@ namespace Cgs.Decks
                 return;
 
             searchResults.ShowSearchMenu();
+        }
+
+        private void InputFocus(InputAction.CallbackContext callbackContext)
+        {
+            if (IsBlocked)
+                return;
+
+            searchResults.inputField.ActivateInputField();
         }
 
         private void InputCancel(InputAction.CallbackContext callbackContext)
@@ -638,8 +637,9 @@ namespace Cgs.Decks
             InputSystem.actions.FindAction(Tags.DecksLoad).performed -= InputLoad;
             InputSystem.actions.FindAction(Tags.DecksSave).performed -= InputSave;
             InputSystem.actions.FindAction(Tags.DecksPivot).performed -= InputPivot;
-            InputSystem.actions.FindAction(Tags.SubMenuFocusNext).performed -= InputFocus;
+            InputSystem.actions.FindAction(Tags.CardsSort).performed -= InputPivot;
             InputSystem.actions.FindAction(Tags.CardsFilter).performed -= InputFilter;
+            InputSystem.actions.FindAction(Tags.SubMenuFocusNext).performed -= InputFocus;
             InputSystem.actions.FindAction(Tags.PlayerCancel).performed -= InputCancel;
         }
     }

--- a/Assets/Scripts/Cgs/Play/PlayHelpMenu.cs
+++ b/Assets/Scripts/Cgs/Play/PlayHelpMenu.cs
@@ -2,6 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Cgs.Menu;
 using UnityEngine;
@@ -14,12 +17,19 @@ namespace Cgs.Play
     {
         private const string MissingInputActionErrorFormat = "PlayHelpMenu: Input Action '{0}' not found.";
 
+        private const string MissingBindingErrorFormat = "PlayHelpMenu: Input Action '{0}' has no '{1}' binding.";
+
+        private const string GamepadGroup = "Gamepad";
+        private const string KeyboardMouseGroup = "Keyboard&Mouse";
+
         private const string MobileHelpText = "Select Card: Tap a card.\n" +
                                               "View Card: Press-and-hold a card to zoom in on it.\n" +
                                               "Move Card: Drag a card with 1 finger.\n" +
                                               "Pan: Drag the play area with 2 fingers.\n" +
                                               "Zoom: Pinch with 2 fingers.\n" +
                                               "Rotate: Twist with 2 fingers, when rotation is enabled.";
+
+        private static readonly string[] PartDisplayOrder = {"up", "left", "down", "right"};
 
         public Text helpText;
 
@@ -63,12 +73,82 @@ namespace Cgs.Play
                 return string.Empty;
             }
 
-            var inputBinding = Gamepad.current != null
-                ? InputBinding.MaskByGroup("Gamepad")
-                : InputBinding.MaskByGroup("Keyboard&Mouse");
-            return inputAction.GetBindingDisplayString(inputBinding)
-                .Replace("| `", "").Replace("| Backspace", "")
-                .Replace("Keypad ", "").Replace("Numpad ", "").Replace("Num ", "");
+            var group = Gamepad.current != null ? GamepadGroup : KeyboardMouseGroup;
+            var bindings = inputAction.bindings;
+            for (var i = 0; i < bindings.Count; i++)
+            {
+                if (bindings[i].isPartOfComposite)
+                    continue;
+
+                // Composite bindings, i.e. Move and Page, do not have groups, so their parts are checked instead.
+                string displayString;
+                if (bindings[i].isComposite)
+                    displayString = GetCompositeDisplayString(inputAction, i, group);
+                else if (IsInGroup(bindings[i], group))
+                    displayString = inputAction.GetBindingDisplayString(i);
+                else
+                    continue;
+
+                if (!string.IsNullOrEmpty(displayString))
+                    return Simplify(displayString);
+            }
+
+            Debug.LogError(string.Format(MissingBindingErrorFormat, inputActionId, group));
+            return string.Empty;
+        }
+
+        private static string GetCompositeDisplayString(InputAction inputAction, int compositeIndex, string group)
+        {
+            var bindings = inputAction.bindings;
+            var partNames = new List<string>();
+            var partDisplayStrings = new Dictionary<string, string>();
+            var partParentPaths = new Dictionary<string, string>();
+            for (var i = compositeIndex + 1; i < bindings.Count && bindings[i].isPartOfComposite; i++)
+            {
+                if (!IsInGroup(bindings[i], group))
+                    continue;
+
+                // Only the last binding of each part is displayed, i.e. Up instead of both W and Up.
+                var partName = bindings[i].name;
+                if (!partDisplayStrings.ContainsKey(partName))
+                    partNames.Add(partName);
+                partDisplayStrings[partName] = inputAction.GetBindingDisplayString(i, out var deviceLayoutName,
+                    out var controlPath);
+                var separatorIndex = controlPath?.IndexOf('/') ?? -1;
+                partParentPaths[partName] = separatorIndex > 0
+                    ? $"<{deviceLayoutName}>/{controlPath[..separatorIndex]}"
+                    : null;
+            }
+
+            if (partNames.Count == 0)
+                return string.Empty;
+
+            // Parts of the same control, i.e. Right Stick Up/Right Stick Down/..., display as just that control.
+            var parentPath = partParentPaths[partNames[0]];
+            if (!string.IsNullOrEmpty(parentPath) && partNames.TrueForAll(partName =>
+                    parentPath == partParentPaths[partName]))
+                return InputControlPath.ToHumanReadableString(parentPath,
+                    InputControlPath.HumanReadableStringOptions.OmitDevice);
+
+            return string.Join("/",
+                partNames.OrderBy(GetPartDisplayOrder).Select(partName => partDisplayStrings[partName]));
+        }
+
+        private static int GetPartDisplayOrder(string partName)
+        {
+            var partDisplayOrder = Array.IndexOf(PartDisplayOrder, partName);
+            return partDisplayOrder >= 0 ? partDisplayOrder : PartDisplayOrder.Length;
+        }
+
+        private static bool IsInGroup(InputBinding inputBinding, string group)
+        {
+            return !string.IsNullOrEmpty(inputBinding.groups) && Array.IndexOf(
+                inputBinding.groups.Split(InputBinding.Separator), group) >= 0;
+        }
+
+        private static string Simplify(string displayString)
+        {
+            return displayString.Replace("Keypad ", "").Replace("Numpad ", "").Replace("Num ", "");
         }
 
         private void InputCancel(InputAction.CallbackContext callbackContext)

--- a/Assets/Scripts/Cgs/Tags.cs
+++ b/Assets/Scripts/Cgs/Tags.cs
@@ -34,9 +34,10 @@ namespace Cgs
         public const string ViewerLess = "Viewer/Less";
         public const string ViewerMore = "Viewer/More";
 
+        public const string CardsGamesManagementMenu = "Cards/GamesManagementMenu";
         public const string CardsNew = "Cards/New";
         public const string CardsEdit = "Cards/Edit";
-        public const string CardsGameManagementMenu = "Cards/GamesManagementMenu";
+        public const string CardsSort = "Cards/Sort";
         public const string CardsFilter = "Cards/Filter";
         public const string CardsPagePrevious = "Cards/PagePrevious";
         public const string CardsPageNext = "Cards/PageNext";


### PR DESCRIPTION
## What's Changed
- The in-game Help menu now shows the actual keys or gamepad controls for moving the selection, moving cards, panning, zooming, and rotating, instead of leaving them blank.
- Added a shortcut for sorting cards in the Cards Explorer and Deck Editor.
- Moved the card count labels for card stacks, dice zones, and card zones to the top-right, so they no longer cover the cards.