### PR TITLE
Fix Deck Editor and Hand layout for non-default card sizes

### DIFF
--- a/Assets/Scripts/Cgs/Decks/DeckEditorLayout.cs
+++ b/Assets/Scripts/Cgs/Decks/DeckEditorLayout.cs
@@ -16,6 +16,13 @@ namespace Cgs.Decks
 
         private bool IsPortrait => ((RectTransform)transform).rect.width < 1200f;
 
+        // The serialized padding suits the landscape search area, which fills the screen height and fills from the top
+        private RectOffset SearchAreaGridPadding => _searchAreaGridPadding ??= new RectOffset(
+            searchAreaGridLayoutGroup.padding.left, searchAreaGridLayoutGroup.padding.right,
+            searchAreaGridLayoutGroup.padding.top, searchAreaGridLayoutGroup.padding.bottom);
+
+        private RectOffset _searchAreaGridPadding;
+
         public RectTransform deckLabelContainer;
         public RectTransform deckLabel;
         public RectTransform deckButtonsContainer;
@@ -34,8 +41,14 @@ namespace Cgs.Decks
             if (!gameObject.activeInHierarchy)
                 return;
 
+            // Capture before either branch can overwrite it
+            var landscapeGridPadding = SearchAreaGridPadding;
+
             if (IsPortrait) // Portrait
             {
+                // Set grid properties first: resizing searchArea below makes SearchResults repaginate off of them
+                SetSearchAreaGridVerticalPadding(0, 0);
+                searchAreaGridLayoutGroup.childAlignment = TextAnchor.MiddleCenter;
                 deckLabel.offsetMax = Vector2.zero;
                 deckEditorButtonsGroup.SetParent(deckButtonsContainer);
                 deckEditorButtonsGroup.anchoredPosition = Vector2.zero;
@@ -49,12 +62,14 @@ namespace Cgs.Decks
                 searchArea.offsetMin = Vector2.down * SearchAreaPortraitHeight;
                 searchArea.offsetMax = Vector2.zero;
                 searchArea.anchoredPosition = Vector2.up * SearchAreaPortraitHeight;
-                searchAreaGridLayoutGroup.childAlignment = TextAnchor.LowerCenter;
                 cardCountLabel.anchoredPosition = Vector2.zero;
                 dockedCardViewer.offsetMin = new Vector2(0, SearchAreaPortraitHeight + 100);
             }
             else // Landscape
             {
+                // Set grid properties first: resizing searchArea below makes SearchResults repaginate off of them
+                SetSearchAreaGridVerticalPadding(landscapeGridPadding.top, landscapeGridPadding.bottom);
+                searchAreaGridLayoutGroup.childAlignment = TextAnchor.UpperCenter;
                 deckLabel.offsetMax = new Vector2(DeckLabelXOffset, 0);
                 deckEditorButtonsGroup.SetParent(deckLabelContainer);
                 deckEditorButtonsGroup.anchoredPosition = Vector2.zero;
@@ -68,10 +83,17 @@ namespace Cgs.Decks
                 searchArea.offsetMin = Vector2.left * SearchAreaLandscapeWidth;
                 searchArea.offsetMax = Vector2.zero;
                 searchArea.anchoredPosition = Vector2.zero;
-                searchAreaGridLayoutGroup.childAlignment = TextAnchor.UpperCenter;
                 cardCountLabel.anchoredPosition = Vector2.zero;
                 dockedCardViewer.offsetMin = Vector2.zero;
             }
+        }
+
+        private void SetSearchAreaGridVerticalPadding(int top, int bottom)
+        {
+            var padding = searchAreaGridLayoutGroup.padding;
+            if (padding.top == top && padding.bottom == bottom)
+                return;
+            searchAreaGridLayoutGroup.padding = new RectOffset(padding.left, padding.right, top, bottom);
         }
     }
 }

--- a/Assets/Scripts/Cgs/Play/Drawer/CardDrawer.cs
+++ b/Assets/Scripts/Cgs/Play/Drawer/CardDrawer.cs
@@ -113,6 +113,9 @@ namespace Cgs.Play.Drawer
             cardZonesRectTransform.sizeDelta = new Vector2(cardZonesRectTransform.sizeDelta.x, cardHeight);
             foreach (var cardZoneRectTransform in cardZoneRectTransforms)
                 cardZoneRectTransform.sizeDelta = new Vector2(cardZoneRectTransform.sizeDelta.x, cardHeight);
+
+            // The serialized position only docks the panel for the default card size, so re-dock for the current one
+            Dock();
         }
 
         private void Show()


### PR DESCRIPTION
The portrait search results grid used LowerCenter alignment with top padding tuned to the default card size, so cards for games like Dominoes were pinned to the bottom with dead space above. Center them instead, and zero the vertical padding in portrait. Set the grid properties before resizing searchArea, since that resize synchronously makes SearchResults repaginate off of them.

CardDrawer.Resize sized the panel for the current card size but left the prefab's anchoredPosition, which docks only a default-height card, so a shorter panel ended up entirely below the screen until a dealt hand moved it up. Re-dock after resizing.