### PR TITLE
Add Move action for card stacks

### DIFF
--- a/Assets/Fonts.meta
+++ b/Assets/Fonts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6b35875cf9bc44eba5fa41a5afaad6df
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Fonts/Noto Sans JP.meta
+++ b/Assets/Fonts/Noto Sans JP.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: acc0461917e8473e856b539440f57f6a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Fonts/Noto Sans JP/NotoSansJP-Regular SDF.asset
+++ b/Assets/Fonts/Noto Sans JP/NotoSansJP-Regular SDF.asset
@@ -1,0 +1,266 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &-5108056410766688081
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: NotoSansJP-Regular SDF Material
+  m_Shader: {fileID: 4800000, guid: fe393ace9b354375a9cb14cdbbc28be4, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 2094702972601437263}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _CullMode: 0
+    - _FaceDilate: 0
+    - _GradientScale: 6
+    - _MaskSoftnessX: 0
+    - _MaskSoftnessY: 0
+    - _OutlineSoftness: 0
+    - _OutlineWidth: 0
+    - _PerspectiveFilter: 0.875
+    - _ScaleRatioA: 1
+    - _ScaleRatioB: 1
+    - _ScaleRatioC: 1
+    - _ScaleX: 1
+    - _ScaleY: 1
+    - _ShaderFlags: 0
+    - _Sharpness: 0
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _TextureHeight: 1024
+    - _TextureWidth: 1024
+    - _UnderlayDilate: 0
+    - _UnderlayOffsetX: 0
+    - _UnderlayOffsetY: 0
+    - _UnderlaySoftness: 0
+    - _VertexOffsetX: 0
+    - _VertexOffsetY: 0
+    - _WeightBold: 0.75
+    - _WeightNormal: 0
+    m_Colors:
+    - _ClipRect: {r: -32767, g: -32767, b: 32767, a: 32767}
+    - _FaceColor: {r: 1, g: 1, b: 1, a: 1}
+    - _OutlineColor: {r: 0, g: 0, b: 0, a: 1}
+    - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.5}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
+  m_Name: NotoSansJP-Regular SDF
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TMP_FontAsset
+  m_Version: 1.1.0
+  m_FaceInfo:
+    m_FaceIndex: 0
+    m_FamilyName: Noto Sans JP
+    m_StyleName: Regular
+    m_PointSize: 48
+    m_Scale: 1
+    m_UnitsPerEM: 1000
+    m_LineHeight: 69.504
+    m_AscentLine: 55.679996
+    m_CapLine: 35
+    m_MeanLine: 26
+    m_Baseline: 0
+    m_DescentLine: -13.823999
+    m_SuperscriptOffset: 55.679996
+    m_SuperscriptSize: 0.5
+    m_SubscriptOffset: -13.823999
+    m_SubscriptSize: 0.5
+    m_UnderlineOffset: -7.2
+    m_UnderlineThickness: 2.3999999
+    m_StrikethroughOffset: 10.4
+    m_StrikethroughThickness: 2.3999999
+    m_TabWidth: 11
+  m_Material: {fileID: -5108056410766688081}
+  m_SourceFontFileGUID: 2aa81dd343c445e69fd0523975d1b810
+  m_CreationSettings:
+    sourceFontFileName: 
+    sourceFontFileGUID: 
+    faceIndex: 0
+    pointSizeSamplingMode: 0
+    pointSize: 0
+    padding: 0
+    paddingMode: 0
+    packingMode: 0
+    atlasWidth: 0
+    atlasHeight: 0
+    characterSetSelectionMode: 0
+    characterSequence: 
+    referencedFontAssetGUID: 
+    referencedTextAssetGUID: 
+    fontStyle: 0
+    fontStyleModifier: 0
+    renderMode: 0
+    includeFontFeatures: 0
+  m_SourceFontFile: {fileID: 12800000, guid: 2aa81dd343c445e69fd0523975d1b810, type: 3}
+  m_SourceFontFilePath: 
+  m_AtlasPopulationMode: 1
+  InternalDynamicOS: 0
+  m_GlyphTable: []
+  m_CharacterTable: []
+  m_AtlasTextures:
+  - {fileID: 2094702972601437263}
+  m_AtlasTextureIndex: 0
+  m_IsMultiAtlasTexturesEnabled: 1
+  m_GetFontFeatures: 1
+  m_ClearDynamicDataOnBuild: 1
+  m_AtlasWidth: 1024
+  m_AtlasHeight: 1024
+  m_AtlasPadding: 5
+  m_AtlasRenderMode: 4165
+  m_UsedGlyphRects: []
+  m_FreeGlyphRects:
+  - m_X: 0
+    m_Y: 0
+    m_Width: 1023
+    m_Height: 1023
+  m_FontFeatureTable:
+    m_MultipleSubstitutionRecords: []
+    m_LigatureSubstitutionRecords:
+    - m_ComponentGlyphIDs: 1c0500000b050000
+      m_LigatureGlyphID: 16196
+    - m_ComponentGlyphIDs: 1c0500005a0500003405000039050000
+      m_LigatureGlyphID: 1941
+    - m_ComponentGlyphIDs: 1c0500005e0500005b0500006d050000
+      m_LigatureGlyphID: 1942
+    - m_ComponentGlyphIDs: 1c050000150500005b050000
+      m_LigatureGlyphID: 1940
+    - m_ComponentGlyphIDs: 3a0500005c050000
+      m_LigatureGlyphID: 1967
+    m_GlyphPairAdjustmentRecords: []
+    m_MarkToBaseAdjustmentRecords: []
+    m_MarkToMarkAdjustmentRecords: []
+  m_ShouldReimportFontFeatures: 0
+  m_FallbackFontAssetTable: []
+  m_FontWeightTable:
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  fontWeights: []
+  normalStyle: 0
+  normalSpacingOffset: 0
+  boldStyle: 0.75
+  boldSpacing: 7
+  italicStyle: 35
+  tabSize: 10
+  m_fontInfo:
+    Name: 
+    PointSize: 0
+    Scale: 0
+    CharacterCount: 0
+    LineHeight: 0
+    Baseline: 0
+    Ascender: 0
+    CapHeight: 0
+    Descender: 0
+    CenterLine: 0
+    SuperscriptOffset: 0
+    SubscriptOffset: 0
+    SubSize: 0
+    Underline: 0
+    UnderlineThickness: 0
+    strikethrough: 0
+    strikethroughThickness: 0
+    TabWidth: 0
+    Padding: 0
+    AtlasWidth: 0
+    AtlasHeight: 0
+  m_glyphInfoList: []
+  m_KerningTable:
+    kerningPairs: []
+  fallbackFontAssets: []
+  atlas: {fileID: 0}
+--- !u!28 &2094702972601437263
+Texture2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: NotoSansJP-Regular SDF Atlas
+  m_ImageContentsHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_IsAlphaChannelOptional: 0
+  serializedVersion: 4
+  m_Width: 1
+  m_Height: 1
+  m_CompleteImageSize: 1
+  m_MipsStripped: 0
+  m_TextureFormat: 1
+  m_MipCount: 1
+  m_IsReadable: 1
+  m_IsPreProcessed: 0
+  m_IgnoreMipmapLimit: 1
+  m_MipmapLimitGroupName: 
+  m_StreamingMipmaps: 0
+  m_StreamingMipmapsPriority: 0
+  m_VTOnly: 0
+  m_AlphaIsTransparency: 0
+  m_ImageCount: 1
+  m_TextureDimension: 2
+  m_TextureSettings:
+    serializedVersion: 2
+    m_FilterMode: 1
+    m_Aniso: 1
+    m_MipBias: 0
+    m_WrapU: 0
+    m_WrapV: 0
+    m_WrapW: 0
+  m_LightmapFormat: 0
+  m_ColorSpace: 0
+  m_PlatformBlob: 
+  image data: 1
+  _typelessdata: 00
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 

--- a/Assets/Fonts/Noto Sans JP/NotoSansJP-Regular SDF.asset.meta
+++ b/Assets/Fonts/Noto Sans JP/NotoSansJP-Regular SDF.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 658a45e59ace9d44b8a494b673ddccdf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Fonts/Noto Sans JP/NotoSansJP-Regular.otf
+++ b/Assets/Fonts/Noto Sans JP/NotoSansJP-Regular.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dff723ba59d57d136764a04b9b2d03205544f7cd785a711442d6d2d085ac5073
+size 4533028

--- a/Assets/Fonts/Noto Sans JP/NotoSansJP-Regular.otf.meta
+++ b/Assets/Fonts/Noto Sans JP/NotoSansJP-Regular.otf.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: 2aa81dd343c445e69fd0523975d1b810
+TrueTypeFontImporter:
+  externalObjects: {}
+  serializedVersion: 4
+  fontSize: 16
+  forceTextureCase: -2
+  characterSpacing: 0
+  characterPadding: 1
+  includeFontData: 1
+  fontName: Noto Sans JP
+  fontNames:
+  - Noto Sans JP
+  fallbackFontReferences: []
+  customCharacters:
+  fontRenderingMode: 0
+  ascentCalculationMode: 1
+  useLegacyBoundsCalculation: 0
+  shouldRoundAdvanceValue: 1
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Fonts/Noto Sans JP/OFL.txt
+++ b/Assets/Fonts/Noto Sans JP/OFL.txt
@@ -1,0 +1,92 @@
+This Font Software is licensed under the SIL Open Font License,
+Version 1.1.
+
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font
+creation efforts of academic and linguistic communities, and to
+provide a free and open framework in which fonts may be shared and
+improved in partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply to
+any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software
+components as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to,
+deleting, or substituting -- in part or in whole -- any of the
+components of the Original Version, by changing formats or by porting
+the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed,
+modify, redistribute, and sell modified and unmodified copies of the
+Font Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components, in
+Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the
+corresponding Copyright Holder. This restriction only applies to the
+primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created using
+the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/Assets/Fonts/Noto Sans JP/OFL.txt.meta
+++ b/Assets/Fonts/Noto Sans JP/OFL.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5982af9578fc490393f398db8cc47cec
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Prefabs/CardGameView/Viewer/Playable Viewer.prefab
+++ b/Assets/Prefabs/CardGameView/Viewer/Playable Viewer.prefab
@@ -256,8 +256,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1436655418735063068}
   - {fileID: 76110154032960270}
+  - {fileID: 1436655418735063068}
   - {fileID: 2372836908336666654}
   - {fileID: 3007206303774861039}
   - {fileID: 3436281376403372465}

--- a/Assets/Prefabs/CardGameView/Viewer/Playable Viewer.prefab
+++ b/Assets/Prefabs/CardGameView/Viewer/Playable Viewer.prefab
@@ -124,6 +124,7 @@ MonoBehaviour:
   dieActionPanel: {fileID: 198146522612501599}
   stackActionPanel: {fileID: 1998985133142810657}
   counterActionPanel: {fileID: 2394856817997104161}
+  saveButton: {fileID: 3007206303774861036}
   valueTexts:
   - {fileID: 7437930296677555684}
   - {fileID: 4159148351361970319}
@@ -256,11 +257,11 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 3436281376403372465}
   - {fileID: 76110154032960270}
   - {fileID: 1436655418735063068}
   - {fileID: 2372836908336666654}
-  - {fileID: 3007206303774861039}
-  - {fileID: 3436281376403372465}
+  - {fileID: 7168796511069880180}
   m_Father: {fileID: 224256216305895768}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
@@ -467,6 +468,7 @@ RectTransform:
   m_Children:
   - {fileID: 4930284540125129299}
   - {fileID: 2701433319441782439}
+  - {fileID: 3007206303774861039}
   - {fileID: 7512204855791781900}
   m_Father: {fileID: 224256216305895768}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1694,7 +1696,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 3750639968265570870}
+    m_TransformParent: {fileID: 6017011295155346931}
     m_Modifications:
     - target: {fileID: 633149931556260068, guid: 050b35c711bf97548b7054e54e7b44b4,
         type: 3}
@@ -1739,17 +1741,17 @@ PrefabInstance:
     - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
         type: 3}
       propertyPath: m_Pivot.x
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
         type: 3}
       propertyPath: m_Pivot.y
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
         type: 3}
@@ -1759,7 +1761,7 @@ PrefabInstance:
     - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
         type: 3}
@@ -1769,7 +1771,7 @@ PrefabInstance:
     - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 300
+      value: 240
       objectReference: {fileID: 0}
     - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
         type: 3}
@@ -1814,7 +1816,7 @@ PrefabInstance:
     - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: -240
       objectReference: {fileID: 0}
     - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
         type: 3}
@@ -1881,6 +1883,18 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 5784142567481430950}
   m_SourcePrefab: {fileID: 100100000, guid: 050b35c711bf97548b7054e54e7b44b4, type: 3}
+--- !u!114 &3007206303774861036 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 633149931556260068, guid: 050b35c711bf97548b7054e54e7b44b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 2410227006813351432}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3007206303774861038}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &3007206303774861038 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 633149931556260070, guid: 050b35c711bf97548b7054e54e7b44b4,
@@ -1968,7 +1982,7 @@ PrefabInstance:
     - target: {fileID: 7456223291527984051, guid: e885b7dcac6cff447a150d9f185e8af7,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: -480
+      value: -720
       objectReference: {fileID: 0}
     - target: {fileID: 7456223291527984051, guid: e885b7dcac6cff447a150d9f185e8af7,
         type: 3}
@@ -2013,7 +2027,7 @@ PrefabInstance:
     - target: {fileID: 7456223291527984051, guid: e885b7dcac6cff447a150d9f185e8af7,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: -120
       objectReference: {fileID: 0}
     - target: {fileID: 7456223291527984051, guid: e885b7dcac6cff447a150d9f185e8af7,
         type: 3}
@@ -3496,6 +3510,230 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ignoreDeselect: 1
+--- !u!1001 &7761330482915604371
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3750639968265570870}
+    m_Modifications:
+    - target: {fileID: 633149931556260068, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260068, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260068, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 7043608188858395400}
+    - target: {fileID: 633149931556260068, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260068, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: MoveStackTopCard
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260068, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: Cgs.CardGameView.Viewer.PlayableViewer, Cgs
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260068, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260070, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_Name
+      value: Move Button
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 85
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5606556387005000519, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: cf799b85ea37aee4a89ad8610115a0a6,
+        type: 3}
+    - target: {fileID: 8387297474274779720, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: isBelow
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8387297474274779720, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: tooltip
+      value: Move Top Card
+      objectReference: {fileID: 0}
+    - target: {fileID: 8387297474274779720, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: avoidOverlap
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8387297474274779720, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: inputActionId
+      value: Card/Move
+      objectReference: {fileID: 0}
+    - target: {fileID: 8387297474274779720, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: parentTransform
+      value: 
+      objectReference: {fileID: 7281582518593460843}
+    - target: {fileID: 8688795498816596447, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      propertyPath: m_Text
+      value: Move
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 633149931556260070, guid: 050b35c711bf97548b7054e54e7b44b4,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7761330482915604374}
+  m_SourcePrefab: {fileID: 100100000, guid: 050b35c711bf97548b7054e54e7b44b4, type: 3}
+--- !u!224 &7168796511069880180 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 633149931556260071, guid: 050b35c711bf97548b7054e54e7b44b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 7761330482915604371}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &7168796511069880181 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 633149931556260070, guid: 050b35c711bf97548b7054e54e7b44b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 7761330482915604371}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7761330482915604374
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7168796511069880181}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf48ea0f1cb2a02428c1bf86966a8deb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ignoreDeselect: 0
+--- !u!224 &7281582518593460843 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1060782754166042104, guid: 050b35c711bf97548b7054e54e7b44b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 7761330482915604371}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8494325918971195621
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Components/InputField.prefab
+++ b/Assets/Prefabs/Components/InputField.prefab
@@ -329,7 +329,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_Font: {fileID: 12800000, guid: 9620f61733f65c749a22b0e4f59b6615, type: 3}
     m_FontSize: 42
     m_FontStyle: 0
     m_BestFit: 0

--- a/Assets/Scripts/Cgs/CardGameView/Viewer/PlayableViewer.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Viewer/PlayableViewer.cs
@@ -70,6 +70,8 @@ namespace Cgs.CardGameView.Viewer
         [FormerlySerializedAs("tokenActionPanel")]
         public CanvasGroup counterActionPanel;
 
+        public Button saveButton;
+
         public List<Text> valueTexts;
         public InputField dieValueInputField;
         public InputField dieMaxInputField;
@@ -116,9 +118,10 @@ namespace Cgs.CardGameView.Viewer
             InputSystem.actions.FindAction(Tags.ViewerLess).performed += InputLess;
             InputSystem.actions.FindAction(Tags.ViewerMore).performed += InputMore;
             InputSystem.actions.FindAction(Tags.DecksSave).performed += InputSave;
+            InputSystem.actions.FindAction(Tags.CardMove).performed += InputMove;
             InputSystem.actions.FindAction(Tags.CardRotate).performed += InputRotate;
-            InputSystem.actions.FindAction(Tags.CardFlip).performed += InputFlip;
             InputSystem.actions.FindAction(Tags.DecksNew).performed += InputShuffle;
+            InputSystem.actions.FindAction(Tags.CardFlip).performed += InputFlip;
             InputSystem.actions.FindAction(Tags.PlayerDelete).performed += InputDelete;
             InputSystem.actions.FindAction(Tags.PlayerCancel).performed += InputCancel;
         }
@@ -192,6 +195,10 @@ namespace Cgs.CardGameView.Viewer
             view.alpha = IsVisible ? 1 : 0;
             view.interactable = IsVisible;
             view.blocksRaycasts = IsVisible;
+
+            // Save sits alongside Delete in the view bar, so it ignores ShowActionsMenu, but it only applies to stacks
+            if (saveButton != null)
+                saveButton.gameObject.SetActive(_selectedPlayable is CardStack);
 
             dieActionPanel.alpha = PlaySettings.ShowActionsMenu && IsVisible && _selectedPlayable is Die ? 1 : 0;
             dieActionPanel.interactable = PlaySettings.ShowActionsMenu && IsVisible && _selectedPlayable is Die;
@@ -492,18 +499,6 @@ namespace Cgs.CardGameView.Viewer
             };
         }
 
-        [UsedImplicitly]
-        public void ViewStack()
-        {
-            if (Stack == null)
-            {
-                Debug.LogWarning("Ignoring view request since there is no stack selected.");
-                return;
-            }
-
-            Stack.View();
-        }
-
         private void InputSave(InputAction.CallbackContext callbackContext)
         {
             if (IsBlocked)
@@ -523,6 +518,33 @@ namespace Cgs.CardGameView.Viewer
             }
 
             Stack.PromptSave();
+        }
+
+        private void InputMove(InputAction.CallbackContext callbackContext)
+        {
+            if (IsBlocked)
+                return;
+
+            if (SelectedPlayable is CardStack)
+                MoveStackTopCard();
+        }
+
+        [UsedImplicitly]
+        public void MoveStackTopCard()
+        {
+            if (Stack == null)
+            {
+                Debug.LogWarning("Ignoring move request since there is no stack selected.");
+                return;
+            }
+
+            if (Stack.Cards.Count < 1)
+            {
+                Debug.LogWarning("Ignoring move request since the selected stack is empty.");
+                return;
+            }
+
+            PlayController.Instance.ShowMoveMenu(Stack);
         }
 
         private void InputRotate(InputAction.CallbackContext callbackContext)
@@ -589,6 +611,18 @@ namespace Cgs.CardGameView.Viewer
         }
 
         [UsedImplicitly]
+        public void ViewStack()
+        {
+            if (Stack == null)
+            {
+                Debug.LogWarning("Ignoring view request since there is no stack selected.");
+                return;
+            }
+
+            Stack.View();
+        }
+
+        [UsedImplicitly]
         public void ChangeCounterColor(int option)
         {
             if (SelectedCounter == null)
@@ -644,9 +678,10 @@ namespace Cgs.CardGameView.Viewer
             InputSystem.actions.FindAction(Tags.ViewerLess).performed -= InputLess;
             InputSystem.actions.FindAction(Tags.ViewerMore).performed -= InputMore;
             InputSystem.actions.FindAction(Tags.DecksSave).performed -= InputSave;
+            InputSystem.actions.FindAction(Tags.CardMove).performed -= InputMove;
             InputSystem.actions.FindAction(Tags.CardRotate).performed -= InputRotate;
-            InputSystem.actions.FindAction(Tags.CardFlip).performed -= InputFlip;
             InputSystem.actions.FindAction(Tags.DecksNew).performed -= InputShuffle;
+            InputSystem.actions.FindAction(Tags.CardFlip).performed -= InputFlip;
             InputSystem.actions.FindAction(Tags.PlayerDelete).performed -= InputDelete;
             InputSystem.actions.FindAction(Tags.PlayerCancel).performed -= InputCancel;
         }

--- a/Assets/Scripts/Cgs/CardGameView/Viewer/PlayableViewer.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Viewer/PlayableViewer.cs
@@ -546,27 +546,6 @@ namespace Cgs.CardGameView.Viewer
             Stack.Rotation *= Quaternion.Euler(0, 0, -CardGameManager.Current.GameCardRotationDegrees);
         }
 
-        private void InputFlip(InputAction.CallbackContext callbackContext)
-        {
-            if (IsBlocked)
-                return;
-
-            if (SelectedPlayable is CardStack)
-                FlipStackTopFace();
-        }
-
-        [UsedImplicitly]
-        public void FlipStackTopFace()
-        {
-            if (Stack == null)
-            {
-                Debug.LogWarning("Ignoring flip top face request since there is no stack selected.");
-                return;
-            }
-
-            Stack.FlipTopFace();
-        }
-
         private void InputShuffle(InputAction.CallbackContext callbackContext)
         {
             if (IsBlocked)
@@ -586,6 +565,27 @@ namespace Cgs.CardGameView.Viewer
             }
 
             Stack.PromptShuffle();
+        }
+
+        private void InputFlip(InputAction.CallbackContext callbackContext)
+        {
+            if (IsBlocked)
+                return;
+
+            if (SelectedPlayable is CardStack)
+                FlipStackTopFace();
+        }
+
+        [UsedImplicitly]
+        public void FlipStackTopFace()
+        {
+            if (Stack == null)
+            {
+                Debug.LogWarning("Ignoring flip top face request since there is no stack selected.");
+                return;
+            }
+
+            Stack.FlipTopFace();
         }
 
         [UsedImplicitly]

--- a/Assets/Scripts/Cgs/Play/MoveMenu.cs
+++ b/Assets/Scripts/Cgs/Play/MoveMenu.cs
@@ -27,6 +27,9 @@ namespace Cgs.Play
         private const string MissingSourceWarningMessage = "Ignoring move request since the card to move is gone.";
         private const string EmptyStackWarningMessage = "Ignoring move request since the selected card stack is empty.";
 
+        private const string MissingStackWarningMessage =
+            "Ignoring move request since there is no card stack to move from.";
+
         public Button moveButton;
 
         private CardModel _selectedCardModel;
@@ -127,6 +130,12 @@ namespace Cgs.Play
 
         public void Show(CardStack selectedCardStack)
         {
+            if (selectedCardStack == null)
+            {
+                Debug.LogWarning(MissingStackWarningMessage);
+                return;
+            }
+
             _selectedCardModel = null;
             _selectedCardStack = selectedCardStack;
             Menu.Show();

--- a/Assets/Scripts/Cgs/Play/MoveMenu.cs
+++ b/Assets/Scripts/Cgs/Play/MoveMenu.cs
@@ -10,6 +10,7 @@ using Cgs.CardGameView.Viewer;
 using Cgs.Menu;
 using Cgs.Play.Multiplayer;
 using Cgs.UI;
+using FinolDigital.Cgs.Json;
 using JetBrains.Annotations;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -22,20 +23,32 @@ namespace Cgs.Play
     public class MoveMenu : SelectionPanel
     {
         private const string DefaultZoneName = "Zone";
+        private const string MissingContainerErrorMessage = "ERROR: Move: Missing selected card container.";
+        private const string MissingSourceWarningMessage = "Ignoring move request since the card to move is gone.";
+        private const string EmptyStackWarningMessage = "Ignoring move request since the selected card stack is empty.";
 
         public Button moveButton;
 
         private CardModel _selectedCardModel;
+        private CardStack _selectedCardStack;
         private ICardContainer _selectedCardContainer;
 
         // Card containers are Unity objects that may have been destroyed since they were selected
         private bool IsSelectedCardContainerAvailable =>
             _selectedCardContainer is Object unityObject && unityObject != null;
 
+        // A card stack deletes itself when it is emptied, which can happen while this menu is open
+        private bool IsSelectedCardStackAvailable => _selectedCardStack != null;
+
+        private bool IsSourceAvailable => _selectedCardModel != null || IsSelectedCardStackAvailable;
+
         private ICardContainer CurrentCardContainer
         {
             get
             {
+                if (IsSelectedCardStackAvailable)
+                    return _selectedCardStack;
+
                 var parentCardZone = _selectedCardModel == null ? null : _selectedCardModel.ParentCardZone;
                 if (parentCardZone == null)
                     return null;
@@ -76,7 +89,7 @@ namespace Cgs.Play
         // Poll for Vector2 inputs
         private void Update()
         {
-            var isMoveable = IsSelectedCardContainerAvailable && toggleGroup.AnyTogglesOn();
+            var isMoveable = IsSourceAvailable && IsSelectedCardContainerAvailable && toggleGroup.AnyTogglesOn();
             if(moveButton.interactable != isMoveable)
                 moveButton.interactable = isMoveable;
 
@@ -107,6 +120,15 @@ namespace Cgs.Play
         public void Show(CardModel selectedCardModel)
         {
             _selectedCardModel = selectedCardModel;
+            _selectedCardStack = null;
+            Menu.Show();
+            BuildCardZoneSelectionOptions();
+        }
+
+        public void Show(CardStack selectedCardStack)
+        {
+            _selectedCardModel = null;
+            _selectedCardStack = selectedCardStack;
             Menu.Show();
             BuildCardZoneSelectionOptions();
         }
@@ -171,28 +193,66 @@ namespace Cgs.Play
         [UsedImplicitly]
         public void Move()
         {
-            if (_selectedCardModel == null || !IsSelectedCardContainerAvailable)
+            // The card to move can be taken by another player while this menu is open
+            if (!IsSourceAvailable)
             {
-                Debug.LogError("ERROR: Move: Missing selected card model or container.");
+                Debug.LogWarning(MissingSourceWarningMessage);
+                Hide();
                 return;
             }
 
+            if (!IsSelectedCardContainerAvailable)
+            {
+                Debug.LogError(MissingContainerErrorMessage);
+                return;
+            }
+
+            if (IsSelectedCardStackAvailable)
+                MoveTopCardOfStack();
+            else
+                MoveSelectedCardModel();
+
+            Hide();
+        }
+
+        private void MoveSelectedCardModel()
+        {
+            AddToSelectedCardContainer(_selectedCardModel.Value, _selectedCardModel.IsFacedown);
+            _selectedCardModel.RequestDelete();
+        }
+
+        // The top card is read now instead of when this menu opened,
+        // since the stack may have been added to or taken from in the meantime
+        private void MoveTopCardOfStack()
+        {
+            var cards = _selectedCardStack.Cards;
+            var topIndex = cards.Count - 1;
+            if (topIndex < 0)
+            {
+                Debug.LogWarning(EmptyStackWarningMessage);
+                return;
+            }
+
+            AddToSelectedCardContainer(cards[topIndex], !_selectedCardStack.IsTopFaceup);
+            _selectedCardStack.RequestRemoveAt(topIndex);
+        }
+
+        // The card is added to its destination before it is removed from its source,
+        // since a card that is briefly duplicated is recoverable but a card that is lost is not
+        private void AddToSelectedCardContainer(Card card, bool isFacedown)
+        {
             switch (_selectedCardContainer)
             {
                 case CardZone cardZone:
-                    cardZone.AddCard(_selectedCardModel.Value, _selectedCardModel.IsFacedown);
+                    cardZone.AddCard(card, isFacedown);
                     break;
                 case PlayController playController:
-                    playController.AddCard(_selectedCardModel.Value, _selectedCardModel.IsFacedown);
+                    playController.AddCard(card, isFacedown);
                     break;
                 default:
-                    _selectedCardContainer.AddCard(_selectedCardModel.Value);
+                    _selectedCardContainer.AddCard(card);
                     break;
             }
-
-            _selectedCardModel.RequestDelete();
-
-            Hide();
         }
 
         private void InputCancel(InputAction.CallbackContext callbackContext)

--- a/Assets/Scripts/Cgs/Play/PlayController.cs
+++ b/Assets/Scripts/Cgs/Play/PlayController.cs
@@ -742,6 +742,12 @@ namespace Cgs.Play
 
         public void ShowMoveMenu(CardStack cardStack)
         {
+            if (cardStack == null)
+            {
+                Debug.LogWarning("Ignoring move request since there is no card stack to move from.");
+                return;
+            }
+
             Mover.Show(cardStack);
         }
 

--- a/Assets/Scripts/Cgs/Play/PlayController.cs
+++ b/Assets/Scripts/Cgs/Play/PlayController.cs
@@ -740,6 +740,11 @@ namespace Cgs.Play
             Mover.Show(cardModel);
         }
 
+        public void ShowMoveMenu(CardStack cardStack)
+        {
+            Mover.Show(cardStack);
+        }
+
         public void AddCard(Card card)
         {
             AddCard(card, false);

--- a/Assets/Tests/PlayMode/JapaneseFontTests.cs
+++ b/Assets/Tests/PlayMode/JapaneseFontTests.cs
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+using System.Linq;
+using NUnit.Framework;
+using TMPro;
+using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Tests.PlayMode
+{
+    /// <summary>
+    /// Open Sans and Liberation Sans carry no CJK glyphs. Desktop and mobile hide that by silently
+    /// falling back to OS-installed fonts, but WebGL has no OS fonts, so Japanese game names came out
+    /// blank there. These tests pin the bundled Noto Sans JP fallback in place on both text stacks.
+    /// </summary>
+    public class JapaneseFontTests
+    {
+        private const string Japanese = "遊戯王カードゲーム";
+
+        private const string OpenSansPath = "Assets/TextMesh Pro/Fonts/Open Sans/OpenSans-Regular.ttf";
+        private const string OpenSansBoldPath = "Assets/TextMesh Pro/Fonts/Open Sans/OpenSans-Bold.ttf";
+
+        [Test]
+        public void BundledJapaneseFont_CoversJapaneseText()
+        {
+            var font = GetJapaneseFallbackFontAsset().sourceFontFile;
+            Assert.IsNotNull(font,
+                "The Japanese TMP font asset must keep a runtime reference to its source font, " +
+                "otherwise the glyphs are stripped from player builds.");
+
+            foreach (var character in Japanese)
+                Assert.IsTrue(font.HasCharacter(character),
+                    $"Bundled Japanese font is missing '{character}'.");
+        }
+
+        [Test]
+        public void TmpSettings_FallBackToFontCoveringJapanese()
+        {
+            var fallback = GetJapaneseFallbackFontAsset();
+
+            Assert.AreEqual(AtlasPopulationMode.Dynamic, fallback.atlasPopulationMode,
+                "The Japanese TMP fallback must use a dynamic atlas so glyphs rasterize on demand.");
+
+            foreach (var character in Japanese)
+                Assert.IsTrue(fallback.HasCharacter(character, false, true),
+                    $"TextMeshPro cannot rasterize '{character}' from the Japanese fallback.");
+        }
+
+#if UNITY_EDITOR
+        [Test]
+        [TestCase(OpenSansPath)]
+        [TestCase(OpenSansBoldPath)]
+        public void OpenSans_FallsBackToFontCoveringJapanese(string fontPath)
+        {
+            var importer = (TrueTypeFontImporter)AssetImporter.GetAtPath(fontPath);
+            Assert.IsNotNull(importer, $"Could not load the font importer for {fontPath}.");
+
+            var fallbacks = importer.fontReferences;
+            Assert.IsNotNull(fallbacks, $"{fontPath} has no fallback fonts.");
+
+            var coversJapanese = fallbacks.Any(fallback =>
+                fallback != null && Japanese.All(fallback.HasCharacter));
+            Assert.IsTrue(coversJapanese,
+                $"{fontPath} needs a fallback font covering Japanese, or WebGL renders it blank.");
+        }
+#endif
+
+        private static TMP_FontAsset GetJapaneseFallbackFontAsset()
+        {
+            var fallbacks = TMP_Settings.fallbackFontAssets;
+            Assert.IsNotNull(fallbacks, "TMP Settings has no fallback font assets.");
+
+            var japaneseFallback = fallbacks.FirstOrDefault(fallback =>
+                fallback != null && fallback.sourceFontFile != null &&
+                Japanese.All(fallback.sourceFontFile.HasCharacter));
+            Assert.IsNotNull(japaneseFallback,
+                "TMP Settings needs a fallback font asset covering Japanese.");
+
+            return japaneseFallback;
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/JapaneseFontTests.cs.meta
+++ b/Assets/Tests/PlayMode/JapaneseFontTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 99d407ee728ac064e93fea9d29a24e30

--- a/Assets/Tests/PlayMode/PlayMode.asmdef
+++ b/Assets/Tests/PlayMode/PlayMode.asmdef
@@ -9,7 +9,8 @@
         "FinolDigital.Cgs.Json.Unity",
         "unity.webp",
         "WebP.Editor",
-        "Unity.Netcode.Runtime"
+        "Unity.Netcode.Runtime",
+        "Unity.TextMeshPro"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/TextMesh Pro/Fonts/Open Sans/OpenSans-Bold.ttf.meta
+++ b/Assets/TextMesh Pro/Fonts/Open Sans/OpenSans-Bold.ttf.meta
@@ -13,6 +13,7 @@ TrueTypeFontImporter:
   - Open Sans
   fallbackFontReferences:
   - {fileID: 12800000, guid: 9620f61733f65c749a22b0e4f59b6615, type: 3}
+  - {fileID: 12800000, guid: 2aa81dd343c445e69fd0523975d1b810, type: 3}
   customCharacters: 
   fontRenderingMode: 0
   ascentCalculationMode: 1

--- a/Assets/TextMesh Pro/Fonts/Open Sans/OpenSans-Regular.ttf.meta
+++ b/Assets/TextMesh Pro/Fonts/Open Sans/OpenSans-Regular.ttf.meta
@@ -11,7 +11,8 @@ TrueTypeFontImporter:
   fontName: Open Sans
   fontNames:
   - Open Sans
-  fallbackFontReferences: []
+  fallbackFontReferences:
+  - {fileID: 12800000, guid: 2aa81dd343c445e69fd0523975d1b810, type: 3}
   customCharacters: 
   fontRenderingMode: 0
   ascentCalculationMode: 1

--- a/Assets/TextMesh Pro/Resources/TMP Settings.asset
+++ b/Assets/TextMesh Pro/Resources/TMP Settings.asset
@@ -33,7 +33,8 @@ MonoBehaviour:
   m_defaultTextMeshProUITextContainerSize: {x: 200, y: 50}
   m_autoSizeTextContainer: 0
   m_IsTextObjectScaleStatic: 0
-  m_fallbackFontAssets: []
+  m_fallbackFontAssets:
+  - {fileID: 11400000, guid: 658a45e59ace9d44b8a494b673ddccdf, type: 2}
   m_matchMaterialPreset: 1
   m_HideSubTextObjects: 1
   m_defaultSpriteAsset: {fileID: 11400000, guid: c41005c129ba4d66911b75229fd70b45,

--- a/openspec/changes/archive/2026-07-27-stack-move-action/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-27-stack-move-action/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/archive/2026-07-27-stack-move-action/design.md
+++ b/openspec/changes/archive/2026-07-27-stack-move-action/design.md
@@ -1,0 +1,71 @@
+## Context
+
+Selecting a card stack in play shows `PlayableViewer` (`Assets/Prefabs/CardGameView/Viewer/Playable Viewer.prefab`). The prefab has two relevant regions:
+
+- **View bar** — a top strip that is visible whenever any playable is selected. It holds the value label and the **Delete** button, which calls `PlayableViewer.DeletePlayable`.
+- **Stack Action Panel** — a `CanvasGroup` shown only when the selected playable is a `CardStack` *and* `PlaySettings.ShowActionsMenu` is on. It currently holds five button prefab instances wired to `ViewStack`, `RotateStack`, `ShuffleStack`, `FlipStackTopFace`, and `SaveStack`.
+
+Card models get their actions from `CardActionPanel`, whose `Move` action calls `PlayController.Instance.ShowMoveMenu(cardModel)` → `MoveMenu.Show(CardModel)`. `MoveMenu` builds a list of `ICardContainer` destinations (Play, Hand, each named card zone, each card stack), lets the player pick one, calls `AddCard` on it, and then calls `RequestDelete()` on the source card model.
+
+`CardStack` already exposes everything a top-card move needs: `Cards` (bottom-to-top), `IsTopFaceup`, and `RequestRemoveAt(int)`, which routes through the server when the stack is spawned and the local client is not the authority, and falls back to `OwnerRemoveAt` otherwise. `CardStack` itself implements `ICardContainer`, so it is already one of the destinations `MoveMenu` offers.
+
+Constraints: solo desktop play runs as a LAN host, so the online path is the common path and must be handled, not treated as an edge case; and the pop must reuse the existing authority routing rather than mutating card lists directly.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give a selected card stack a Move action that behaves, from the player's point of view, exactly like Move on a card model — same menu, same destination list, same face handling.
+- Reuse `MoveMenu` and `CardStack`'s existing authority-aware mutation methods rather than adding a parallel move path.
+- Relocate Save to sit beside Delete in the View bar, shown only for card stacks.
+- Keep the Stack Action Panel at five buttons so its layout and sizing are unchanged.
+
+**Non-Goals:**
+
+- Moving more than one card at a time, moving the bottom card, or moving an arbitrary card from inside the stack. (The stack viewer already allows dragging any card out.)
+- Moving a whole stack to another container — dropping one stack onto another already merges them.
+- Changing `MoveMenu`'s destination list, its layout, or its input handling.
+- Changing what Save writes or where it writes it.
+
+## Decisions
+
+### Decision 1: Extend `MoveMenu` with a card-stack source rather than materializing a temporary `CardModel`
+
+`MoveMenu.Move()` is written against `_selectedCardModel`: it reads `Value` and `IsFacedown` from it and calls `RequestDelete()` on it afterward. Two ways to support a stack:
+
+- **(A) Chosen** — give `MoveMenu` a second source field, `_selectedCardStack`, set by a new `Show(CardStack)` overload. `Move()` resolves the card value and facedown flag from whichever source is set, and removes from whichever source is set. `CurrentCardContainer` returns the stack itself when the source is a stack, which makes the existing "remove the current container from the options" line exclude the source stack for free.
+- **(B) Rejected** — instantiate a hidden `CardModel` for the top card, pop it from the stack up front, and hand it to the existing `Show(CardModel)`. This reuses more code, but it commits the pop before the player has chosen a destination: cancelling the menu, or the menu being destroyed by a scene change, would leak the card out of the stack, and a network round trip would already have removed it from every other player's view.
+
+(A) keeps the stack authoritative until the player confirms, which is the behavior that matters.
+
+### Decision 2: Read the top card at confirm time, not at menu-open time
+
+The top card is captured when `Move()` runs, not when the menu opens. In an online game another player can drag from or drop onto the same stack while the menu is open; capturing at open time would move a card that is no longer on top. If the stack has been emptied (and therefore deleted) by the time the player confirms, `Move()` aborts with a warning and closes the menu rather than moving a blank card.
+
+### Decision 3: Add to the destination first, then remove from the stack
+
+`Move()` calls `AddCard` on the destination and only then calls `RequestRemoveAt(Cards.Count - 1)` on the source stack, mirroring the existing card-model ordering (`AddCard` then `RequestDelete`). Duplicating a card briefly is recoverable; losing one is not.
+
+`RequestRemoveAt` is used rather than the `OwnerPopCard`/`RequestRemoveAt` branch that `CardStack.DragCard` writes out by hand, because `RequestRemoveAt` already encapsulates that branch and is public. Note that removing the last card causes `CardStack` to delete itself, which is the same as what happens when the last card is dragged off.
+
+### Decision 4: Facedown state comes from `IsTopFaceup`
+
+The moved card is facedown when `!stack.IsTopFaceup`, so a face-down deck yields a face-down card and a flipped-up deck yields a face-up card. This matches `CardStack.DragCard`, which passes `!IsTopFaceup` as the facedown flag when a card is dragged off the top. The destination may still override this: `PlayController.AddCard` clears facedown for back-face cards, and card zones apply their own face preference.
+
+### Decision 5: Move is driven by `PlayableViewer`, using the existing `Card/Move` input action
+
+`PlayableViewer` gets `MoveStackTopCard()` next to `RotateStack`/`ShuffleStack`/`FlipStackTopFace`, and subscribes to `Tags.CardMove` the way it already subscribes to `Tags.CardRotate` and `Tags.CardFlip`. `CardActionPanel` also listens to `Card/Move`, but the two never both fire: `CardActionPanel.IsBlocked` requires its own canvas group to be interactable (a card model must be selected), and `PlayableViewer.IsBlocked` requires a playable to be selected. No new input action or binding is added.
+
+### Decision 6: Save's visibility is driven by `Redisplay()`, not by a new panel
+
+The Save button is reparented in the prefab from the Stack Action Panel to the View bar, immediately after the Delete button, keeping its existing `SaveStack` click binding. `PlayableViewer` gains a `public Button saveButton` reference and, in `Redisplay()`, activates it only when `SelectedPlayable is CardStack`. A die or counter selection shows Delete alone, as it does today.
+
+Consequence, and it is intended: the View bar ignores `PlaySettings.ShowActionsMenu`, so Save becomes reachable for a stack even when the actions menu is turned off. Delete already works that way. The `Decks/Save` keyboard shortcut is unaffected — it is handled by `PlayableViewer.InputSave`, which is gated on the selected playable being a `CardStack`, not on the button's parent.
+
+## Risks / Trade-offs
+
+- **A concurrent pop makes the moved card differ from the one the player saw** → The window is the few seconds the menu is open, and the outcome ("the top card moves") still holds. Capturing at confirm time keeps the stack and the destination consistent, which is the property worth protecting.
+- **Add succeeds and remove fails (ownership lost mid-move, host disconnects)** → The card is duplicated rather than lost. Chosen deliberately over the reverse ordering; matches the existing card-model move.
+- **Moving the last card deletes the stack while the menu is closing** → `MoveMenu` already guards its container reference with `IsSelectedCardContainerAvailable` (a destroyed Unity object test); the source stack reference gets the same treatment before it is dereferenced.
+- **Save in the View bar competes for width with Delete on narrow phone screens** → The View bar's layout is checked at a phone aspect ratio during implementation; the buttons are the same prefab and size as the ones already in the bar.
+- **Players used to Save in the actions menu will not find it** → Save keeps its label, icon, tooltip, and keyboard shortcut, and the View bar is on-screen whenever a stack is selected, so it is more visible than before, not less.

--- a/openspec/changes/archive/2026-07-27-stack-move-action/proposal.md
+++ b/openspec/changes/archive/2026-07-27-stack-move-action/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+A card in play can be sent to any other container through the Move menu, but a card sitting on top of a stack cannot — the only way to get it somewhere else is to drag it there, which is awkward on touch screens and impossible when the destination is off-screen or is another player's stack. The stack action menu also spends one of its five slots on Save, an infrequent, whole-stack operation that has nothing to do with manipulating the stack in play.
+
+## What Changes
+
+- Add a **Move** action to the card stack action menu, alongside View, Rotate, Shuffle, and Flip. It takes the top card off the stack and opens the same Move menu used by card models, so the top card can be sent to the play area, a hand, a card zone, or another stack.
+- The Move action respects the stack's face state: a stack whose top face is down yields a facedown card, and a face-up stack yields a face-up card.
+- The stack itself is excluded from the Move menu's destination list, and the action is unavailable for an empty stack.
+- Bind the existing `Card/Move` input action to the stack Move action, matching how `Card/Rotate` and `Card/Flip` already drive the stack Rotate and Flip actions.
+- **Move the Save button out of the stack action menu** and into the playable viewer's top bar, immediately next to the Delete button. Save is shown there only while a card stack is selected.
+- Because the top bar is not governed by the "Show Actions Menu" play setting, Save becomes reachable even when the actions menu is hidden — Delete already behaves this way.
+
+## Capabilities
+
+### New Capabilities
+- `stack-actions`: The set of actions offered for a selected card stack in the playable viewer — View, Rotate, Shuffle, Flip, and the new Move — plus where the Save action lives and when it is available.
+
+### Modified Capabilities
+
+*(none — no existing spec in `openspec/specs/` covers the stack action menu)*
+
+## Impact
+
+- `Assets/Scripts/Cgs/CardGameView/Viewer/PlayableViewer.cs` — new `MoveStackTopCard` action, `Card/Move` input handling, Save button visibility tied to the selected playable being a card stack.
+- `Assets/Scripts/Cgs/Play/MoveMenu.cs` — new entry point for moving a card stack's top card, including source-container exclusion and removal of the moved card from the stack.
+- `Assets/Scripts/Cgs/Play/PlayController.cs` — overload of `ShowMoveMenu` for a card stack.
+- `Assets/Prefabs/CardGameView/Viewer/Playable Viewer.prefab` — add a Move button to the Stack Action Panel; reparent the Save button to the View bar next to Delete.
+- No changes to networking contracts: the move reuses `CardStack.RequestRemoveAt` and the existing `ICardContainer.AddCard` paths.

--- a/openspec/changes/archive/2026-07-27-stack-move-action/specs/stack-actions/spec.md
+++ b/openspec/changes/archive/2026-07-27-stack-move-action/specs/stack-actions/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: A selected card stack offers a Move action
+The card stack action menu SHALL offer a Move action alongside View, Rotate, Shuffle, and Flip. Activating Move SHALL open the same move menu that the Move action on a card model opens, listing the play area, the hand, every named card zone, and every card stack as destinations.
+
+#### Scenario: Move action opens the move menu
+- **WHEN** a card stack is selected and the player activates the stack's Move action
+- **THEN** the move menu opens with the same destination list a card model's Move action would show
+
+#### Scenario: Source stack is not a destination
+- **WHEN** the move menu is opened from a card stack
+- **THEN** that stack does not appear among the destinations
+
+#### Scenario: Move via the Card/Move input action
+- **WHEN** a card stack is selected and the player triggers the `Card/Move` input action
+- **THEN** the stack's Move action runs, the same as activating the Move button
+
+### Requirement: Confirming a move takes the top card off the stack
+When the player confirms a destination in a move menu opened from a card stack, the system SHALL add the stack's top card to the chosen destination and then remove that card from the stack, leaving the rest of the stack in place and in order.
+
+#### Scenario: Top card moved to the play area
+- **WHEN** the player opens Move on a stack of three cards and confirms "Play"
+- **THEN** the stack's top card appears in the play area, the stack holds the remaining two cards in their original order, and the move menu closes
+
+#### Scenario: Top card moved to another stack
+- **WHEN** the player opens Move on a stack and confirms another card stack as the destination
+- **THEN** the moved card is added to the top of the destination stack and removed from the source stack
+
+#### Scenario: Move is not confirmed
+- **WHEN** the player opens Move on a stack and cancels the move menu instead of confirming a destination
+- **THEN** the stack is unchanged and still holds its top card
+
+#### Scenario: Moving the last card
+- **WHEN** the player moves the top card of a stack that holds exactly one card
+- **THEN** the card is added to the destination and the now-empty stack is removed from play, as it is when its last card is dragged off
+
+#### Scenario: Stack emptied while the move menu is open
+- **WHEN** the stack a move menu was opened from no longer exists or holds no cards at the moment the player confirms a destination
+- **THEN** no card is added to the destination and the move menu closes
+
+### Requirement: A moved card keeps the stack's face state
+The card produced by a stack Move SHALL be facedown when the stack's top face is down and face up when the stack's top face is up, matching the card produced by dragging the top card off that stack. Destination-specific face rules SHALL continue to apply to the moved card.
+
+#### Scenario: Moving off a face-down stack
+- **WHEN** the top card of a face-down stack is moved to the play area
+- **THEN** the card arrives facedown
+
+#### Scenario: Moving off a flipped-up stack
+- **WHEN** the stack's top face has been flipped face up and its top card is moved to the play area
+- **THEN** the card arrives face up
+
+#### Scenario: Destination overrides the face state
+- **WHEN** the top card of a face-down stack is moved into a card zone whose default face preference is up
+- **THEN** the card arrives face up, as it would when dropped into that zone
+
+### Requirement: Save is presented next to Delete for card stacks
+The Save action SHALL be presented in the playable viewer's top bar immediately next to the Delete action, and SHALL NOT appear in the card stack action menu. It SHALL be shown only while the selected playable is a card stack.
+
+#### Scenario: Save shown for a selected stack
+- **WHEN** a card stack is selected
+- **THEN** the top bar shows a Save button next to the Delete button, and the stack action menu shows View, Rotate, Shuffle, Flip, and Move only
+
+#### Scenario: Save hidden for other playables
+- **WHEN** a die or a counter is selected
+- **THEN** the top bar shows Delete without a Save button
+
+#### Scenario: Save available with the actions menu hidden
+- **WHEN** the "Show Actions Menu" play setting is off and a card stack is selected
+- **THEN** the Save button is still shown and usable, as the Delete button already is
+
+#### Scenario: Saving is unchanged
+- **WHEN** the player activates Save for a selected card stack, from the button or from the `Decks/Save` shortcut
+- **THEN** the same save prompt appears and the same deck file is written as before the button moved

--- a/openspec/changes/archive/2026-07-27-stack-move-action/tasks.md
+++ b/openspec/changes/archive/2026-07-27-stack-move-action/tasks.md
@@ -1,0 +1,40 @@
+## 1. Move menu accepts a card stack source
+
+- [x] 1.1 In `MoveMenu.cs`, add a `_selectedCardStack` field and a `Show(CardStack selectedCardStack)` overload that clears `_selectedCardModel`, sets the stack, shows the modal, and builds the destination options; make `Show(CardModel)` clear `_selectedCardStack` symmetrically
+- [x] 1.2 Add an `IsSelectedCardStackAvailable` guard (destroyed-Unity-object test) alongside the existing `IsSelectedCardContainerAvailable`
+- [x] 1.3 Make `CurrentCardContainer` return the selected card stack when the source is a stack, so `BuildCardZoneSelectionOptions` removes the source stack from the destination list
+- [x] 1.4 In `Update()`, keep `moveButton.interactable` false unless a source (card model or card stack) is available and a destination toggle is on
+- [x] 1.5 Extend `Move()` to handle the stack source: read the top card and `!IsTopFaceup` at confirm time, abort with a warning and `Hide()` if the stack is gone or empty, add the card to the destination through the existing `CardZone`/`PlayController`/`ICardContainer` switch, then call `RequestRemoveAt(Cards.Count - 1)` on the source stack
+- [x] 1.6 Add `PlayController.ShowMoveMenu(CardStack cardStack)` calling `Mover.Show(cardStack)`
+
+## 2. Stack Move action in the playable viewer
+
+- [x] 2.1 Add `PlayableViewer.MoveStackTopCard()` next to `RotateStack`/`ShuffleStack`/`FlipStackTopFace`, warning and returning when no stack is selected or the stack has no cards, otherwise calling `PlayController.Instance.ShowMoveMenu(Stack)`
+- [x] 2.2 Add `InputMove` and subscribe/unsubscribe `Tags.CardMove` in `OnEnable`/`OnDisable`, gated on `IsBlocked` and on the selected playable being a `CardStack`
+- [x] 2.3 Verify no double-fire against `CardActionPanel`'s `Card/Move` handler: with a card model selected only `CardActionPanel` reacts, with a stack selected only `PlayableViewer` reacts
+
+## 3. Save button relocation
+
+- [x] 3.1 Add a `public Button saveButton` field to `PlayableViewer`
+- [x] 3.2 In `Redisplay()`, activate `saveButton` only when `SelectedPlayable is CardStack`, independent of `PlaySettings.ShowActionsMenu`
+- [x] 3.3 Confirm `InputSave` still routes the `Decks/Save` shortcut to `SaveStack` for a selected stack
+
+## 4. Playable Viewer prefab wiring
+
+- [x] 4.1 Reparent the existing Save Button from the Stack Action Panel to the View bar, positioned immediately next to the Delete Button, keeping its `SaveStack` click binding, label, icon, and tooltip
+- [x] 4.2 Assign the reparented Save Button to the new `saveButton` field on the `PlayableViewer` component
+- [x] 4.3 Add a Move Button to the Stack Action Panel from the same button prefab the other stack actions use, with text "Move", a "Move Top Card" tooltip, the move icon used by the card action panel, and an `OnClick` bound to `PlayableViewer.MoveStackTopCard`
+- [x] 4.4 Order the Stack Action Panel as View, Move, Rotate, Shuffle, Flip and confirm the panel still holds five buttons with unchanged sizing
+- [x] 4.5 Check the View bar layout at a phone aspect ratio so Save and Delete both fit without clipping
+
+## 5. Verification
+
+- [x] 5.1 Offline (WebGL/solo): move the top card of a face-down stack to Play, Hand, a card zone, and another stack; confirm face state, stack order, and count label
+- [x] 5.2 Offline: flip the stack top face up, move the top card, and confirm it arrives face up
+- [x] 5.3 Offline: move the only card of a one-card stack and confirm the empty stack is removed
+- [x] 5.4 Offline: open Move on a stack and cancel; confirm the stack is unchanged
+- [x] 5.5 Online (LAN host plus a client): move a top card from a stack the client does not own and confirm both players see the same result and count
+- [x] 5.6 Online: empty the source stack from a second client while the move menu is open, then confirm; verify the abort path leaves no blank card behind
+- [x] 5.7 Turn off "Show Actions Menu", select a stack, and confirm Save and Delete are both usable while the stack action menu stays hidden
+- [x] 5.8 Select a die and a counter and confirm the top bar shows Delete with no Save button
+- [x] 5.9 Run `unity command run_tests --mode playmode --async_tests` and confirm no regressions (26/27 pass; `CanGetGames` fails on DNS for aminduna.arcmage.org, unrelated to this change)

--- a/openspec/specs/stack-actions/spec.md
+++ b/openspec/specs/stack-actions/spec.md
@@ -1,0 +1,76 @@
+# stack-actions Specification
+
+## Purpose
+The set of actions offered for a selected card stack in the playable viewer — View, Rotate, Shuffle, Flip, and Move — plus where the Save action lives and when it is available.
+## Requirements
+### Requirement: A selected card stack offers a Move action
+The card stack action menu SHALL offer a Move action alongside View, Rotate, Shuffle, and Flip. Activating Move SHALL open the same move menu that the Move action on a card model opens, listing the play area, the hand, every named card zone, and every card stack as destinations.
+
+#### Scenario: Move action opens the move menu
+- **WHEN** a card stack is selected and the player activates the stack's Move action
+- **THEN** the move menu opens with the same destination list a card model's Move action would show
+
+#### Scenario: Source stack is not a destination
+- **WHEN** the move menu is opened from a card stack
+- **THEN** that stack does not appear among the destinations
+
+#### Scenario: Move via the Card/Move input action
+- **WHEN** a card stack is selected and the player triggers the `Card/Move` input action
+- **THEN** the stack's Move action runs, the same as activating the Move button
+
+### Requirement: Confirming a move takes the top card off the stack
+When the player confirms a destination in a move menu opened from a card stack, the system SHALL add the stack's top card to the chosen destination and then remove that card from the stack, leaving the rest of the stack in place and in order.
+
+#### Scenario: Top card moved to the play area
+- **WHEN** the player opens Move on a stack of three cards and confirms "Play"
+- **THEN** the stack's top card appears in the play area, the stack holds the remaining two cards in their original order, and the move menu closes
+
+#### Scenario: Top card moved to another stack
+- **WHEN** the player opens Move on a stack and confirms another card stack as the destination
+- **THEN** the moved card is added to the top of the destination stack and removed from the source stack
+
+#### Scenario: Move is not confirmed
+- **WHEN** the player opens Move on a stack and cancels the move menu instead of confirming a destination
+- **THEN** the stack is unchanged and still holds its top card
+
+#### Scenario: Moving the last card
+- **WHEN** the player moves the top card of a stack that holds exactly one card
+- **THEN** the card is added to the destination and the now-empty stack is removed from play, as it is when its last card is dragged off
+
+#### Scenario: Stack emptied while the move menu is open
+- **WHEN** the stack a move menu was opened from no longer exists or holds no cards at the moment the player confirms a destination
+- **THEN** no card is added to the destination and the move menu closes
+
+### Requirement: A moved card keeps the stack's face state
+The card produced by a stack Move SHALL be facedown when the stack's top face is down and face up when the stack's top face is up, matching the card produced by dragging the top card off that stack. Destination-specific face rules SHALL continue to apply to the moved card.
+
+#### Scenario: Moving off a face-down stack
+- **WHEN** the top card of a face-down stack is moved to the play area
+- **THEN** the card arrives facedown
+
+#### Scenario: Moving off a flipped-up stack
+- **WHEN** the stack's top face has been flipped face up and its top card is moved to the play area
+- **THEN** the card arrives face up
+
+#### Scenario: Destination overrides the face state
+- **WHEN** the top card of a face-down stack is moved into a card zone whose default face preference is up
+- **THEN** the card arrives face up, as it would when dropped into that zone
+
+### Requirement: Save is presented next to Delete for card stacks
+The Save action SHALL be presented in the playable viewer's top bar immediately next to the Delete action, and SHALL NOT appear in the card stack action menu. It SHALL be shown only while the selected playable is a card stack.
+
+#### Scenario: Save shown for a selected stack
+- **WHEN** a card stack is selected
+- **THEN** the top bar shows a Save button next to the Delete button, and the stack action menu shows View, Rotate, Shuffle, Flip, and Move only
+
+#### Scenario: Save hidden for other playables
+- **WHEN** a die or a counter is selected
+- **THEN** the top bar shows Delete without a Save button
+
+#### Scenario: Save available with the actions menu hidden
+- **WHEN** the "Show Actions Menu" play setting is off and a card stack is selected
+- **THEN** the Save button is still shown and usable, as the Delete button already is
+
+#### Scenario: Saving is unchanged
+- **WHEN** the player activates Save for a selected card stack, from the button or from the `Decks/Save` shortcut
+- **THEN** the same save prompt appears and the same deck file is written as before the button moved


### PR DESCRIPTION
## What's Changed
- You can now move the top card of a stack to the play area, your hand, a card zone, or another stack, using the new Move button in the stack menu (or the Move shortcut). The card keeps the stack's face-up or face-down state.
- The Save button for stacks has moved up next to Delete, so you can save a stack even with the actions menu hidden.
- Japanese text now displays correctly in the web version.