### PR TITLE
Improve Cards Explorer footer layout

### DIFF
--- a/Assets/Scenes/CardsExplorer.unity
+++ b/Assets/Scenes/CardsExplorer.unity
@@ -979,6 +979,7 @@ MonoBehaviour:
   - {fileID: 1473139182}
   - {fileID: 1558182032}
   searchResults: {fileID: 508283654}
+  explorerLayout: {fileID: 508283656}
 --- !u!114 &508283654
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1028,6 +1029,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   cardsViewContent: {fileID: 21480367}
+  cardsViewGrid: {fileID: 21480368}
+  footer: {fileID: 101628742}
+  pageCountText: {fileID: 1272889841}
+  newCardButton: {fileID: 2140515672}
+  editCardButton: {fileID: 1558182031}
+  deleteCardButton: {fileID: 1473139181}
 --- !u!1001 &799426865
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Cgs/Cards/CardsExplorer.cs
+++ b/Assets/Scripts/Cgs/Cards/CardsExplorer.cs
@@ -34,6 +34,7 @@ namespace Cgs.Cards
         public Image bannerImage;
         public List<GameObject> editButtons;
         public SearchResults searchResults;
+        public CardsExplorerLayout explorerLayout;
 
         private GamesManagementMenu GamesManagement =>
             _gamesManagement ??= Instantiate(gamesManagementMenuPrefab).GetOrAddComponent<GamesManagementMenu>();
@@ -78,6 +79,7 @@ namespace Cgs.Cards
             bannerImage.sprite = CardGameManager.Current.BannerImageSprite;
             foreach (var button in editButtons)
                 button.SetActive(Settings.DeveloperMode && !CardGameManager.Current.IsUploaded);
+            explorerLayout.ResetLayout();
         }
 
         private void InputFocus(InputAction.CallbackContext context)

--- a/Assets/Scripts/Cgs/Cards/CardsExplorerLayout.cs
+++ b/Assets/Scripts/Cgs/Cards/CardsExplorerLayout.cs
@@ -3,27 +3,104 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace Cgs.Cards
 {
     public class CardsExplorerLayout : MonoBehaviour
     {
-        private const float MinWidth = 1200f;
+        private const float MinWidth = 1500f;
         private const float CardsPortraitHeight = 5000f;
         private const float CardsLandscapeHeight = 2000f;
+        private const float FooterRowHeight = 100f;
+        private const float FooterButtonWidth = 175f;
+        private const float FooterButtonHeight = 80f;
+        private const float FooterButtonBuffer = 20f;
+
+        private static readonly Vector2 FooterButtonRowPivot = new(0.5f, 0);
+        private static readonly Vector2 NewButtonPosition = new(65, 2.5f);
+        private static readonly Vector2 EditButtonPosition = new(240, 2.5f);
+        private static readonly Vector2 DeleteButtonPosition = new(-65, 2.5f);
+        private static readonly Vector2 FooterButtonRowPosition = new(0, 2.5f);
+
+        private bool IsPortrait => ((RectTransform) transform).rect.width < MinWidth;
+
+        private bool AreEditButtonsVisible => newCardButton != null && newCardButton.gameObject.activeSelf;
+
+        private bool HasTwoFooterRows => IsPortrait && AreEditButtonsVisible;
 
         public RectTransform cardsViewContent;
+        public GridLayoutGroup cardsViewGrid;
+
+        public RectTransform footer;
+        public RectTransform pageCountText;
+        public RectTransform newCardButton;
+        public RectTransform editCardButton;
+        public RectTransform deleteCardButton;
 
         private void OnRectTransformDimensionsChange()
+        {
+            ResetLayout();
+        }
+
+        public void ResetLayout()
         {
             if (!gameObject.activeInHierarchy)
                 return;
 
+            var hasTwoFooterRows = HasTwoFooterRows;
+            var footerHeight = hasTwoFooterRows ? FooterRowHeight * 2 : FooterRowHeight;
+
+            footer.sizeDelta = new Vector2(footer.sizeDelta.x, footerHeight);
+            pageCountText.anchoredPosition = new Vector2(0, footerHeight - FooterRowHeight);
+            if (hasTwoFooterRows)
+                SetFooterButtonsToSecondRow();
+            else
+                SetFooterButtonsToFirstRow();
+
+            SetCardsViewBottomPadding(Mathf.RoundToInt(footerHeight));
+
             var sizeDelta = cardsViewContent.sizeDelta;
-            sizeDelta = ((RectTransform) transform).rect.width < MinWidth
-                ? new Vector2(sizeDelta.x, CardsPortraitHeight)
-                : new Vector2(sizeDelta.x, CardsLandscapeHeight);
-            cardsViewContent.sizeDelta = sizeDelta;
+            cardsViewContent.sizeDelta =
+                new Vector2(sizeDelta.x, IsPortrait ? CardsPortraitHeight : CardsLandscapeHeight);
+        }
+
+        private void SetFooterButtonsToFirstRow()
+        {
+            var buttonSize = new Vector2(FooterButtonWidth, FooterButtonHeight);
+            SetFooterButton(newCardButton, Vector2.zero, Vector2.zero, buttonSize, NewButtonPosition);
+            SetFooterButton(editCardButton, Vector2.zero, Vector2.zero, buttonSize, EditButtonPosition);
+            SetFooterButton(deleteCardButton, Vector2.right, Vector2.right, buttonSize, DeleteButtonPosition);
+        }
+
+        private void SetFooterButtonsToSecondRow()
+        {
+            var buttonWidth = Mathf.Clamp(footer.rect.width / 3f - FooterButtonBuffer, 0, FooterButtonWidth);
+            var buttonSize = new Vector2(buttonWidth, FooterButtonHeight);
+            SetFooterButton(newCardButton, new Vector2(1 / 6f, 0), FooterButtonRowPivot, buttonSize,
+                FooterButtonRowPosition);
+            SetFooterButton(editCardButton, new Vector2(3 / 6f, 0), FooterButtonRowPivot, buttonSize,
+                FooterButtonRowPosition);
+            SetFooterButton(deleteCardButton, new Vector2(5 / 6f, 0), FooterButtonRowPivot, buttonSize,
+                FooterButtonRowPosition);
+        }
+
+        private static void SetFooterButton(RectTransform button, Vector2 anchor, Vector2 pivot, Vector2 size,
+            Vector2 position)
+        {
+            button.anchorMin = anchor;
+            button.anchorMax = anchor;
+            button.pivot = pivot;
+            button.sizeDelta = size;
+            button.anchoredPosition = position;
+        }
+
+        private void SetCardsViewBottomPadding(int bottom)
+        {
+            var padding = cardsViewGrid.padding;
+            if (padding.bottom == bottom)
+                return;
+            cardsViewGrid.padding = new RectOffset(padding.left, padding.right, padding.top, bottom);
         }
     }
 }


### PR DESCRIPTION
## What's Changed
- The New, Edit, and Delete card buttons now move to their own row on narrow screens, so they no longer overlap the page count or run off the edge.
- The card grid now leaves the right amount of space at the bottom, so the last row of cards is never hidden behind the buttons.
