### PR TITLE
Only prompt to draw a hand if the hand is empty

### DIFF
--- a/Assets/Scripts/Cgs/Play/Drawer/CardDrawer.cs
+++ b/Assets/Scripts/Cgs/Play/Drawer/CardDrawer.cs
@@ -37,6 +37,17 @@ namespace Cgs.Play.Drawer
 
         private static bool IsBlocked => PlayController.Instance != null && PlayController.Instance.IsBlocked;
 
+        public bool HasCards
+        {
+            get
+            {
+                if (CgsNetManager.Instance != null && CgsNetManager.Instance.IsOnline &&
+                    CgsNetManager.Instance.LocalPlayer != null)
+                    return CgsNetManager.Instance.LocalPlayer.HandCards.Any(handCards => handCards.Count > 0);
+                return cardZonesRectTransform.GetComponentsInChildren<CardModel>(true).Length > 0;
+            }
+        }
+
         public StackViewer viewer;
         public Dropdown cardStackDropdown;
         public Button downButton;

--- a/Assets/Scripts/Cgs/Play/PlayController.cs
+++ b/Assets/Scripts/Cgs/Play/PlayController.cs
@@ -698,7 +698,7 @@ namespace Cgs.Play
 
         private void PromptForHand()
         {
-            if (CardGameManager.Current.GameStartHandCount > 0)
+            if (CardGameManager.Current.GameStartHandCount > 0 && !drawer.HasCards)
                 ShowDealer();
         }
 

--- a/Assets/Scripts/Cgs/Play/PlayHelpMenu.cs
+++ b/Assets/Scripts/Cgs/Play/PlayHelpMenu.cs
@@ -40,10 +40,16 @@ namespace Cgs.Play
         private static RotateZoomableScrollRect PlayArea =>
             PlayController.Instance != null ? PlayController.Instance.playArea : null;
 
+        private static PlayMatRotationZoomController RotationZoomController =>
+            PlayController.Instance != null
+                ? PlayController.Instance.GetComponent<PlayMatRotationZoomController>()
+                : null;
+
         private void OnEnable()
         {
             InputSystem.actions.FindAction(Tags.PlayGameHelp).performed += InputCancel;
             InputSystem.actions.FindAction(Tags.PlayerCancel).performed += InputCancel;
+            InputSystem.actions.FindAction(Tags.PlayGameToggleZoomRotation).performed += InputToggleZoomRotation;
         }
 
         public override void Show()
@@ -199,10 +205,25 @@ namespace Cgs.Play
             Hide();
         }
 
+        private void InputToggleZoomRotation(InputAction.CallbackContext callbackContext)
+        {
+            if (IsBlocked)
+                return;
+
+            var rotationZoomController = RotationZoomController;
+            if (rotationZoomController == null)
+                return;
+
+            rotationZoomController.ToggleRotation();
+            rotationZoomController.ToggleZoom();
+            SyncToggles();
+        }
+
         private void OnDisable()
         {
             InputSystem.actions.FindAction(Tags.PlayGameHelp).performed -= InputCancel;
             InputSystem.actions.FindAction(Tags.PlayerCancel).performed -= InputCancel;
+            InputSystem.actions.FindAction(Tags.PlayGameToggleZoomRotation).performed -= InputToggleZoomRotation;
         }
     }
 }


### PR DESCRIPTION
## What's Changed
- When you load a deck, you will only be asked to draw a starting hand if you don't already have cards in your hand
- You can now toggle rotation and zoom controls in the Play Help Menu