### PR TITLE
Fix input

### DIFF
--- a/Assets/InputSystem_Actions.inputactions
+++ b/Assets/InputSystem_Actions.inputactions
@@ -1697,7 +1697,7 @@
                 {
                     "name": "",
                     "id": "526441d0-2659-4e5e-b0c1-63b00ff46ac2",
-                    "path": "<Gamepad>/leftTrigger",
+                    "path": "<Gamepad>/leftShoulder",
                     "interactions": "",
                     "processors": "",
                     "groups": ";Gamepad",
@@ -1730,7 +1730,7 @@
                 {
                     "name": "",
                     "id": "9de0afee-168d-4664-8979-2f075564203b",
-                    "path": "<Gamepad>/leftShoulder",
+                    "path": "<Gamepad>/rightShoulder",
                     "interactions": "",
                     "processors": "",
                     "groups": ";Gamepad",
@@ -1762,6 +1762,17 @@
                 },
                 {
                     "name": "",
+                    "id": "c72c9180-4203-4ba0-b15b-6b097fe8066a",
+                    "path": "<Gamepad>/leftTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Action0",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
                     "id": "0c3615de-1030-4e2e-95b4-100dfe36ce80",
                     "path": "<Keyboard>/numpad0",
                     "interactions": "",
@@ -1779,6 +1790,17 @@
                     "processors": "",
                     "groups": ";Keyboard&Mouse",
                     "action": "Action0",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "6269c183-2a00-44b3-9bc2-8b08c6176261",
+                    "path": "<Gamepad>/rightTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Action1",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardModel.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CardModel.cs
@@ -621,6 +621,9 @@ namespace Cgs.CardGameView.Multiplayer
                 return;
 #endif
 
+            if (PointerPositions.Count == 0)
+                return;
+
             if (DropTarget == null && PlaceHolder == null && ParentCardZone == null)
                 HighlightMode = HighlightMode.Warn;
             else if (CurrentDragPhase != DragPhase.End)

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CgsNetPlayable.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CgsNetPlayable.cs
@@ -367,26 +367,32 @@ namespace Cgs.CardGameView.Multiplayer
             OnUpdatePlayable();
         }
 
+        private static int _anyPointerPressedCacheFrame = -1;
+        private static bool _anyPointerPressedCache;
+
         private static bool IsAnyPointerPressed
         {
             get
             {
+                if (_anyPointerPressedCacheFrame == Time.frameCount)
+                    return _anyPointerPressedCache;
+
+                _anyPointerPressedCacheFrame = Time.frameCount;
+
                 if (Mouse.current != null && (Mouse.current.leftButton.isPressed ||
                                               Mouse.current.rightButton.isPressed ||
                                               Mouse.current.middleButton.isPressed))
-                    return true;
+                    return _anyPointerPressedCache = true;
 
                 if (Pen.current != null && Pen.current.tip.isPressed)
-                    return true;
+                    return _anyPointerPressedCache = true;
 
-                if (Touchscreen.current == null)
-                    return false;
+                if (Touchscreen.current != null)
+                    foreach (var touch in Touchscreen.current.touches)
+                        if (touch.press.isPressed)
+                            return _anyPointerPressedCache = true;
 
-                foreach (var touch in Touchscreen.current.touches)
-                    if (touch.press.isPressed)
-                        return true;
-
-                return false;
+                return _anyPointerPressedCache = false;
             }
         }
 

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CgsNetPlayable.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CgsNetPlayable.cs
@@ -394,11 +394,16 @@ namespace Cgs.CardGameView.Multiplayer
         {
             Debug.Log($"PruneStalePointers for {gameObject.name}");
             _stalePointerTime = 0;
+            if (CurrentDragPhase is DragPhase.Begin or DragPhase.Drag)
+            {
+                var eventData = CurrentPointerEventData ?? new PointerEventData(EventSystem.current);
+                OnEndDrag(eventData);
+                Visibility.blocksRaycasts = true;
+            }
+
             PointerPositions.Clear();
             PointerDragOffsets.Clear();
             DidDrag = false;
-            if (CurrentDragPhase == DragPhase.Drag)
-                CurrentDragPhase = DragPhase.End;
             foreach (var pointerId in DraggedPlayables.Where(pair => pair.Value == this)
                          .Select(pair => pair.Key).ToList())
                 DraggedPlayables.Remove(pointerId);

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CgsNetPlayable.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CgsNetPlayable.cs
@@ -49,6 +49,8 @@ namespace Cgs.CardGameView.Multiplayer
         private const float RotationAnimationDuration = 0.25f;
         private const float RotationAnimationMinDegrees = 1f;
 
+        private const float StalePointerPruneSeconds = 0.5f;
+
         public CardZone ParentCardZone => transform.parent != null ? transform.parent.GetComponent<CardZone>() : null;
 
         protected bool LacksOwnership => IsSpawned && !IsOwner;
@@ -200,6 +202,7 @@ namespace Cgs.CardGameView.Multiplayer
         protected float HoldTime { get; private set; }
 
         private float _disownedTime;
+        private float _stalePointerTime;
         private Vector2 _previousPosition;
 
         public bool ToDelete { get; private set; }
@@ -347,12 +350,58 @@ namespace Cgs.CardGameView.Multiplayer
 
         private void Update()
         {
+            if (PointerPositions.Count > 0 && !IsAnyPointerPressed)
+            {
+                _stalePointerTime += Time.deltaTime;
+                if (_stalePointerTime > StalePointerPruneSeconds)
+                    PruneStalePointers();
+            }
+            else
+                _stalePointerTime = 0;
+
             if (PointerPositions.Count > 0 && !DidDrag && !(Mouse.current?.rightButton?.isPressed ?? false))
                 HoldTime += Time.deltaTime;
             else
                 HoldTime = 0;
 
             OnUpdatePlayable();
+        }
+
+        private static bool IsAnyPointerPressed
+        {
+            get
+            {
+                if (Mouse.current != null && (Mouse.current.leftButton.isPressed ||
+                                              Mouse.current.rightButton.isPressed ||
+                                              Mouse.current.middleButton.isPressed))
+                    return true;
+
+                if (Pen.current != null && Pen.current.tip.isPressed)
+                    return true;
+
+                if (Touchscreen.current == null)
+                    return false;
+
+                foreach (var touch in Touchscreen.current.touches)
+                    if (touch.press.isPressed)
+                        return true;
+
+                return false;
+            }
+        }
+
+        private void PruneStalePointers()
+        {
+            Debug.Log($"PruneStalePointers for {gameObject.name}");
+            _stalePointerTime = 0;
+            PointerPositions.Clear();
+            PointerDragOffsets.Clear();
+            DidDrag = false;
+            if (CurrentDragPhase == DragPhase.Drag)
+                CurrentDragPhase = DragPhase.End;
+            foreach (var pointerId in DraggedPlayables.Where(pair => pair.Value == this)
+                         .Select(pair => pair.Key).ToList())
+                DraggedPlayables.Remove(pointerId);
         }
 
         protected virtual void OnUpdatePlayable()
@@ -409,11 +458,10 @@ namespace Cgs.CardGameView.Multiplayer
 
             CurrentPointerEventData = eventData;
 
-            if (CurrentDragPhase == DragPhase.Drag)
+            if (DraggedPlayables.TryGetValue(eventData.pointerId, out var draggedPlayable) && draggedPlayable == this)
                 return;
 
-            PointerPositions.Remove(eventData.pointerId);
-            PointerDragOffsets.Remove(eventData.pointerId);
+            RemovePointer(eventData);
             if (DidDrag && PointerDragOffsets.Count == 0)
                 DidDrag = false;
         }
@@ -590,6 +638,9 @@ namespace Cgs.CardGameView.Multiplayer
                                           || Mouse.current.rightButton.wasReleasedThisFrame))
                 return;
 #endif
+
+            if (PointerPositions.Count == 0)
+                return;
 
             if (ParentCardZone == null)
                 HighlightMode = HighlightMode.Warn;

--- a/Assets/Scripts/Cgs/CardGameView/Multiplayer/CgsNetPlayable.cs
+++ b/Assets/Scripts/Cgs/CardGameView/Multiplayer/CgsNetPlayable.cs
@@ -392,7 +392,9 @@ namespace Cgs.CardGameView.Multiplayer
 
         private void PruneStalePointers()
         {
+#if UNITY_EDITOR
             Debug.Log($"PruneStalePointers for {gameObject.name}");
+#endif
             _stalePointerTime = 0;
             if (CurrentDragPhase is DragPhase.Begin or DragPhase.Drag)
             {

--- a/Assets/Scripts/Cgs/UI/ScrollRects/RotateZoomableScrollRect.cs
+++ b/Assets/Scripts/Cgs/UI/ScrollRects/RotateZoomableScrollRect.cs
@@ -178,6 +178,12 @@ namespace Cgs.UI.ScrollRects
 
         private void Update()
         {
+            if (PointerPositions.Count > 0 && Touch.activeTouches.Count == 0
+                && (Mouse.current == null || !(Mouse.current.leftButton.isPressed
+                                               || Mouse.current.rightButton.isPressed
+                                               || Mouse.current.middleButton.isPressed)))
+                PointerPositions.Clear();
+
             // Touch zoom
             var touches = new List<Vector2>(Touch.activeTouches.Select(touch => touch.screenPosition));
             for (var i = touches.Count - 1; i >= 0; i--)

--- a/Assets/Scripts/Cgs/UI/ScrollRects/RotateZoomableScrollRect.cs
+++ b/Assets/Scripts/Cgs/UI/ScrollRects/RotateZoomableScrollRect.cs
@@ -181,7 +181,8 @@ namespace Cgs.UI.ScrollRects
             if (PointerPositions.Count > 0 && Touch.activeTouches.Count == 0
                 && (Mouse.current == null || !(Mouse.current.leftButton.isPressed
                                                || Mouse.current.rightButton.isPressed
-                                               || Mouse.current.middleButton.isPressed)))
+                                               || Mouse.current.middleButton.isPressed))
+                && !(Pen.current?.tip?.isPressed ?? false))
                 PointerPositions.Clear();
 
             // Touch zoom


### PR DESCRIPTION
This pull request introduces improvements to pointer handling and input actions, primarily focusing on better management of stale pointer states and more accurate gamepad button mappings. The changes help prevent issues caused by lingering pointer data and ensure that gamepad controls are mapped to the correct actions.

**Pointer State Management Improvements:**

* Added logic to automatically clear stale pointer data from `PointerPositions` and related collections in `CgsNetPlayable` if no pointer is pressed for a short period (`StalePointerPruneSeconds`), preventing stuck drag states and ensuring consistent interaction behavior. [[1]](diffhunk://#diff-9aacb00be6bfcb047fc7a855face4bca359f2bc7af1ceaf54d9528f4f41dec5aR52-R53) [[2]](diffhunk://#diff-9aacb00be6bfcb047fc7a855face4bca359f2bc7af1ceaf54d9528f4f41dec5aR353-R361) [[3]](diffhunk://#diff-9aacb00be6bfcb047fc7a855face4bca359f2bc7af1ceaf54d9528f4f41dec5aR370-R406) [[4]](diffhunk://#diff-9aacb00be6bfcb047fc7a855face4bca359f2bc7af1ceaf54d9528f4f41dec5aL412-R464)
* Introduced a similar stale pointer clearing mechanism in `RotateZoomableScrollRect` to clear pointer positions when no touch or mouse buttons are pressed.
* Updated `UpdatePosition()` in both `CgsNetPlayable` and `CardModel` to early-exit if there are no active pointer positions, reducing unnecessary processing. [[1]](diffhunk://#diff-9aacb00be6bfcb047fc7a855face4bca359f2bc7af1ceaf54d9528f4f41dec5aR642-R644) [[2]](diffhunk://#diff-9d9d328315f6c25a8201be3e8355b53580c5fca5e9b3783b8e2ce6cf685921cfR624-R626)

**Gamepad Input Mapping Fixes:**

* Corrected gamepad button mappings in `InputSystem_Actions.inputactions`, ensuring that `leftShoulder`, `rightShoulder`, `leftTrigger`, and `rightTrigger` are correctly assigned to the intended actions. Previously, some actions were mapped to the wrong buttons. [[1]](diffhunk://#diff-3eff43aa772ffc5ced0e91f066715ed53081745877fa57fcf88a78875e37b186L1700-R1700) [[2]](diffhunk://#diff-3eff43aa772ffc5ced0e91f066715ed53081745877fa57fcf88a78875e37b186L1733-R1733) [[3]](diffhunk://#diff-3eff43aa772ffc5ced0e91f066715ed53081745877fa57fcf88a78875e37b186R1763-R1773) [[4]](diffhunk://#diff-3eff43aa772ffc5ced0e91f066715ed53081745877fa57fcf88a78875e37b186R1796-R1806)