### PR TITLE
Rename playerCount to playerSeat

### DIFF
--- a/Assets/Scripts/Cgs/Play/Multiplayer/CgsNetPlayer.cs
+++ b/Assets/Scripts/Cgs/Play/Multiplayer/CgsNetPlayer.cs
@@ -227,7 +227,7 @@ namespace Cgs.Play.Multiplayer
             if (IsServer)
             {
                 _seatIndex.Value = NextAvailableSeatIndex;
-                Debug.Log($"[CgsNet Player] Assigned seat {_seatIndex.Value} to client {OwnerClientId}");
+                Debug.Log($"[CgsNet Player] Assigned seatIndex {_seatIndex.Value} to client {OwnerClientId}");
             }
 
             if (!GetComponent<NetworkObject>().IsOwner)
@@ -483,16 +483,16 @@ namespace Cgs.Play.Multiplayer
             if (sharedStack != null)
                 sharedStack.IsDeckShared = true;
             _cardStacks.Add(CurrentDeck);
-            ShareDeckOwnerClientRpc(NetworkManager.Singleton.ConnectedClients.Count, OwnerClientRpcParams);
+            ShareDeckOwnerClientRpc(SeatIndex + 1, OwnerClientRpcParams);
         }
 
         [ClientRpc]
         // ReSharper disable once UnusedParameter.Local
         // ReSharper disable once MemberCanBeMadeStatic.Local
-        private void ShareDeckOwnerClientRpc(int playerCount, ClientRpcParams clientRpcParams = default)
+        private void ShareDeckOwnerClientRpc(int playerSeat, ClientRpcParams clientRpcParams = default)
         {
-            Debug.Log($"[CgsNet Player] Received share deck callback for {playerCount}!");
-            PlayController.Instance.DecksCallback(CardStacks, playerCount);
+            Debug.Log($"[CgsNet Player] Received share deck callback for playerSeat {playerSeat}!");
+            PlayController.Instance.DecksCallback(CardStacks, playerSeat);
         }
 
         public void RequestDecks(int deckCount)
@@ -513,16 +513,16 @@ namespace Cgs.Play.Multiplayer
         {
             while (CardStacks.Count < deckCount)
                 yield return null;
-            DecksCallbackOwnerClientRpc(NetworkManager.Singleton.ConnectedClients.Count, OwnerClientRpcParams);
+            DecksCallbackOwnerClientRpc(SeatIndex + 1, OwnerClientRpcParams);
         }
 
         [ClientRpc]
         // ReSharper disable once UnusedParameter.Local
         // ReSharper disable once MemberCanBeMadeStatic.Local
-        private void DecksCallbackOwnerClientRpc(int playerCount, ClientRpcParams clientRpcParams = default)
+        private void DecksCallbackOwnerClientRpc(int playerSeat, ClientRpcParams clientRpcParams = default)
         {
-            Debug.Log($"[CgsNet Player] Received decks callback for {playerCount}!");
-            PlayController.Instance.DecksCallback(CardStacks, playerCount);
+            Debug.Log($"[CgsNet Player] Received decks callback for playerSeat {playerSeat}!");
+            PlayController.Instance.DecksCallback(CardStacks, playerSeat);
         }
 
         public void RequestShuffle(GameObject toShuffle)

--- a/Assets/Scripts/Cgs/Play/PlayController.cs
+++ b/Assets/Scripts/Cgs/Play/PlayController.cs
@@ -604,11 +604,8 @@ namespace Cgs.Play
         public void DecksCallback(IReadOnlyList<CardStack> cardStacks, int playerSeat)
         {
             var supportedSeatCount = GetSupportedSeatCount();
-            if (playerSeat < 1 || playerSeat > supportedSeatCount)
-            {
+            if (supportedSeatCount > 0 && (playerSeat < 1 || playerSeat > supportedSeatCount))
                 Debug.LogError(string.Format(InvalidPlayerSeatMessage, playerSeat, supportedSeatCount));
-                return;
-            }
 
             var decksToCardsToPlay = FindDeckToCardsToPlay(cardStacks, playerSeat);
 

--- a/Assets/Scripts/Cgs/Play/PlayController.cs
+++ b/Assets/Scripts/Cgs/Play/PlayController.cs
@@ -600,9 +600,9 @@ namespace Cgs.Play
             return cardStack;
         }
 
-        public void DecksCallback(IReadOnlyList<CardStack> cardStacks, int playerCount)
+        public void DecksCallback(IReadOnlyList<CardStack> cardStacks, int playerSeat)
         {
-            var decksToCardsToPlay = FindDeckToCardsToPlay(cardStacks, playerCount);
+            var decksToCardsToPlay = FindDeckToCardsToPlay(cardStacks, playerSeat);
 
             var deckPlayCardsAsk = BuildAskForDeckPlayCards(decksToCardsToPlay);
             if (!string.IsNullOrEmpty(deckPlayCardsAsk))
@@ -613,11 +613,11 @@ namespace Cgs.Play
         }
 
         private static Dictionary<DeckPlayCard, Dictionary<CardStack, List<int>>> FindDeckToCardsToPlay(
-            IReadOnlyList<CardStack> cardStacks, int playerCount)
+            IReadOnlyList<CardStack> cardStacks, int playerSeat)
         {
             var deckToCardsToPlay = new Dictionary<DeckPlayCard, Dictionary<CardStack, List<int>>>();
 
-            var deckQuery = "playerCount=" + playerCount;
+            var deckQuery = "playerSeat=" + playerSeat;
             foreach (var deckPlayCard in CardGameManager.Current.DeckPlayCards.Where(deckPlayCard =>
                          string.IsNullOrEmpty(deckPlayCard.DeckQuery) || deckPlayCard.DeckQuery.Equals(deckQuery)))
                 deckToCardsToPlay[deckPlayCard] = FindCardsToPlay(deckPlayCard, cardStacks);

--- a/Assets/Scripts/Cgs/Play/PlayController.cs
+++ b/Assets/Scripts/Cgs/Play/PlayController.cs
@@ -36,6 +36,7 @@ namespace Cgs.Play
         public const string MainMenuPrompt = "Go back to the main menu?";
         public const string RestartPrompt = "Restart?";
         public const string DefaultStackName = "Stack";
+        public const string InvalidPlayerSeatMessage = "Invalid playerSeat {0}. Supported playerSeat range is 1 through {1}.";
 
         public static string LoadStartDecksAsk
         {
@@ -542,7 +543,7 @@ namespace Cgs.Play
                     i++;
                 }
 
-                DecksCallback(cardStacks, 1);
+                DecksCallback(cardStacks, blockIndex + 1);
             }
         }
 
@@ -602,6 +603,13 @@ namespace Cgs.Play
 
         public void DecksCallback(IReadOnlyList<CardStack> cardStacks, int playerSeat)
         {
+            var supportedSeatCount = GetSupportedSeatCount();
+            if (playerSeat < 1 || playerSeat > supportedSeatCount)
+            {
+                Debug.LogError(string.Format(InvalidPlayerSeatMessage, playerSeat, supportedSeatCount));
+                return;
+            }
+
             var decksToCardsToPlay = FindDeckToCardsToPlay(cardStacks, playerSeat);
 
             var deckPlayCardsAsk = BuildAskForDeckPlayCards(decksToCardsToPlay);
@@ -610,6 +618,13 @@ namespace Cgs.Play
                     () => MoveToPlay(decksToCardsToPlay));
             else
                 PromptForHand();
+        }
+
+        private static int GetSupportedSeatCount()
+        {
+            var slotsPerPlayer = 1 + ExtraGroupNames.Count;
+            var deckPositionCount = CardGameManager.Current.GamePlayDeckPositions.Count;
+            return deckPositionCount % slotsPerPlayer == 0 ? deckPositionCount / slotsPerPlayer : 0;
         }
 
         private static Dictionary<DeckPlayCard, Dictionary<CardStack, List<int>>> FindDeckToCardsToPlay(

--- a/docs/games/grand_archive/cgs.json
+++ b/docs/games/grand_archive/cgs.json
@@ -140,7 +140,7 @@
 	"deckPlayCards": [
 		{
 			"cardQuery": "classes:spirit",
-			"deckQuery": "playerCount=1",
+			"deckQuery": "playerSeat=1",
 			"position": {
 				"x": -20,
 				"y": -5.5
@@ -149,7 +149,7 @@
 		},
 		{
 			"cardQuery": "classes:spirit",
-			"deckQuery": "playerCount=2",
+			"deckQuery": "playerSeat=2",
 			"position": {
 				"x": 20,
 				"y": 5.5

--- a/docs/games/grand_archive/grand_archive.json
+++ b/docs/games/grand_archive/grand_archive.json
@@ -120,7 +120,7 @@
 	"deckPlayCards": [
 		{
 			"cardQuery": "classes:spirit",
-			"deckQuery": "playerCount=1",
+			"deckQuery": "playerSeat=1",
 			"position": {
 				"x": -20,
 				"y": -5.5
@@ -129,7 +129,7 @@
 		},
 		{
 			"cardQuery": "classes:spirit",
-			"deckQuery": "playerCount=2",
+			"deckQuery": "playerSeat=2",
 			"position": {
 				"x": 20,
 				"y": 5.5

--- a/docs/games/grand_archive_pantheon/cgs.json
+++ b/docs/games/grand_archive_pantheon/cgs.json
@@ -140,7 +140,7 @@
 	"deckPlayCards": [
 		{
 			"cardQuery": "classes:spirit",
-			"deckQuery": "playerCount=1",
+			"deckQuery": "playerSeat=1",
 			"position": {
 				"x": -20,
 				"y": -5.5
@@ -149,7 +149,7 @@
 		},
 		{
 			"cardQuery": "classes:spirit",
-			"deckQuery": "playerCount=2",
+			"deckQuery": "playerSeat=2",
 			"position": {
 				"x": 20,
 				"y": 5.5
@@ -158,7 +158,7 @@
 		},
 		{
 			"cardQuery": "classes:spirit",
-			"deckQuery": "playerCount=3",
+			"deckQuery": "playerSeat=3",
 			"position": {
 				"x": 20,
 				"y": -5.5
@@ -167,7 +167,7 @@
 		},
 		{
 			"cardQuery": "classes:spirit",
-			"deckQuery": "playerCount=4",
+			"deckQuery": "playerSeat=4",
 			"position": {
 				"x": 48,
 				"y": 5.5

--- a/docs/games/grand_archive_spoilers/cgs.json
+++ b/docs/games/grand_archive_spoilers/cgs.json
@@ -149,7 +149,7 @@
 	"deckPlayCards": [
 		{
 			"cardQuery": "classes:spirit",
-			"deckQuery": "playerCount=1",
+			"deckQuery": "playerSeat=1",
 			"position": {
 				"x": -20,
 				"y": -5.5
@@ -158,7 +158,7 @@
 		},
 		{
 			"cardQuery": "classes:spirit",
-			"deckQuery": "playerCount=2",
+			"deckQuery": "playerSeat=2",
 			"position": {
 				"x": 20,
 				"y": 5.5


### PR DESCRIPTION
This pull request updates the way deck queries are handled for Grand Archive games, standardizing the terminology from `playerCount` to `playerSeat` throughout both the codebase and related game data files. This ensures that deck queries are based on the player's seat number rather than the total player count, improving clarity and consistency.

**Code updates:**

* Changed method parameters and internal variable names from `playerCount` to `playerSeat` in `PlayController.cs` to reflect the new terminology and logic. [[1]](diffhunk://#diff-f2031e1f55be89b7af3396d2550513353626115726c6e59634a98c84a0084ec2L603-R605) [[2]](diffhunk://#diff-f2031e1f55be89b7af3396d2550513353626115726c6e59634a98c84a0084ec2L616-R620)

**Game data updates:**

* Updated all `deckQuery` fields from `playerCount=X` to `playerSeat=X` in the following JSON files to match the new convention:
  * `docs/games/grand_archive/cgs.json` [[1]](diffhunk://#diff-dfdb79ce48de5ab3c1f933b70a7518f7b063fb58825a6572347b0c7aa98a0c0cL143-R143) [[2]](diffhunk://#diff-dfdb79ce48de5ab3c1f933b70a7518f7b063fb58825a6572347b0c7aa98a0c0cL152-R152)
  * `docs/games/grand_archive/grand_archive.json` [[1]](diffhunk://#diff-909223e95f58027a2e2b77b9e5e53fbcab2e383ebbc614c5b34cd4533bb2d0bbL123-R123) [[2]](diffhunk://#diff-909223e95f58027a2e2b77b9e5e53fbcab2e383ebbc614c5b34cd4533bb2d0bbL132-R132)
  * `docs/games/grand_archive_pantheon/cgs.json` [[1]](diffhunk://#diff-062f7bd69cd486539607dc5f848fb9f2f8a2670a939cacc01e3184a833958214L143-R143) [[2]](diffhunk://#diff-062f7bd69cd486539607dc5f848fb9f2f8a2670a939cacc01e3184a833958214L152-R152) [[3]](diffhunk://#diff-062f7bd69cd486539607dc5f848fb9f2f8a2670a939cacc01e3184a833958214L161-R161) [[4]](diffhunk://#diff-062f7bd69cd486539607dc5f848fb9f2f8a2670a939cacc01e3184a833958214L170-R170)
  * `docs/games/grand_archive_spoilers/cgs.json` [[1]](diffhunk://#diff-87d6f47ebc05a14cfdcd5aa37e541c143e2342a6949a90b8978e5df444716e0eL152-R152) [[2]](diffhunk://#diff-87d6f47ebc05a14cfdcd5aa37e541c143e2342a6949a90b8978e5df444716e0eL161-R161)